### PR TITLE
feature ファイルエンコーディングをUTF-8(with BOM)に変更

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ if(UNIX)
   endif()
 endif()
 
-if(UNIX)   # gcc‚ÅSHIFT-JIS‚ð“Ç‚Þ‚½‚ß
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -finput-charset=cp932")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexec-charset=cp932")
-endif()
-
 SET(CMAKE_BUILD_TYPE "Release")
 
 add_subdirectory(cui cui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-project(LittleSLAM)
+Ôªøproject(LittleSLAM)
 
 cmake_minimum_required(VERSION 2.8)
 
-# C++11ÇégÇ§
+# C++11„Çí‰Ωø„ÅÜ
 if(UNIX)
   include(CheckCXXCompilerFlag)
   CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
-# LittleSLAM
+﻿# LittleSLAM
 
-## LittleSLAM�ɂ���
+## LittleSLAMについて
 
-LittleSLAM�́ASLAM�w�K�p�v���O�����ł��B
-2D���[�U�X�L���i�̃f�[�^�i�X�L�����j�ƃI�h���g���f�[�^���i�[�����t�@�C������͂��A
-���{�b�g�ʒu�̋O�Ղ�2D�_�Q�n�}��gnuplot��ɏo�͂��܂��B
+LittleSLAMは、SLAM学習用プログラムです。
+2Dレーザスキャナのデータ（スキャン）とオドメトリデータを格納したファイルを入力し、
+ロボット位置の軌跡と2D点群地図をgnuplot上に出力します。
 
-LittleSLAM�́A�X�L�����}�b�`���O�Ɋ�Â��ʒu�����A���[�U�X�L���i�ƃI�h���g���̃Z���T�Z���A
-Graph-based SLAM�Ɋ�Â����[�v�����݂Ȃǂ̗v�f�Z�p����\������Ă��܂��B
+LittleSLAMは、スキャンマッチングに基づく位置合せ、レーザスキャナとオドメトリのセンサ融合、
+Graph-based SLAMに基づくループ閉じ込みなどの要素技術から構成されています。
 
-LittleSLAM�͎Q�l����[1]�̋��ނƂ��č��ꂽ�v���O�����ł���A
-�킩��₷����D�悵�ăV���v���ȃA���S���Y�����̗p���Ă��܂��B
-���̂��߁A�t���X�y�b�N��SLAM�v���O�����Ɣ�ׂ�Ɛ��\�͗����܂����A
-���e�̗����͂��₷���Ȃ��Ă��܂��B
+LittleSLAMは参考書籍[1]の教材として作られたプログラムであり、
+わかりやすさを優先してシンプルなアルゴリズムを採用しています。
+そのため、フルスペックのSLAMプログラムと比べると性能は落ちますが、
+内容の理解はしやすくなっています。
 
 
-## ���s��
+## 実行環境
 
-LittleSLAM�̓v���O���~���O����C++�ŋL�q����Ă��܂��B
-������m�F�������s���͉��L�̂��̂ł��B�������64�r�b�g�łł��B
+LittleSLAMはプログラミング言語C++で記述されています。
+動作を確認した実行環境は下記のものです。いずれも64ビット版です。
 
 | OS | C++ |
 |:--:|:---:|
@@ -27,60 +27,60 @@ LittleSLAM�̓v���O���~���O����C++�ŋL�q����Ă��܂��B
 | Linux Ubuntu 14.04 LTS | gcc 4.8.4|
 | Linux Ubuntu 16.04 LTS | gcc 5.4.0|
 
-32�r�b�gOS�ł̓���m�F�͂��Ă��Ȃ��̂ŁA�K�v�ȏꍇ�͂������Ŏ����Ă��������B
+32ビットOSでの動作確認はしていないので、必要な場合はご自分で試してください。
 
 
-## �K�v�ȃ\�t�g�E�F�A
+## 必要なソフトウェア
 
-LittleSLAM�̎��s�ɂ́A���L�̃\�t�g�E�F�A���K�v�ł��B
+LittleSLAMの実行には、下記のソフトウェアが必要です。
 
-| �\�t�g�E�F�A | ���e | �o�[�W���� |
+| ソフトウェア | 内容 | バージョン |
 |:------------:|:----:|:----------:|
-| Boost        | C++�ėp���C�u���� |1.58.0 |
-| Eigen3       | ���`�㐔���C�u����|3.2.4 |
-| gnuplot      | �O���t�`��c�[��  |5.0 |
-| CMake        | �r���h�x���c�[��  |3.2.2 |
-| p2o          | Graph-based SLAM�\���o|beta |
+| Boost        | C++汎用ライブラリ |1.58.0 |
+| Eigen3       | 線形代数ライブラリ|3.2.4 |
+| gnuplot      | グラフ描画ツール  |5.0 |
+| CMake        | ビルド支援ツール  |3.2.2 |
+| p2o          | Graph-based SLAMソルバ|beta |
 
-�o�[�W������LittleSLAM�̊J���Ŏg�p�������̂ł���A���m�ȏ����ł͂���܂���B
-����ȏ�̃o�[�W�����ł���Βʏ�͓��삵�܂��B
-����ȉ��̃o�[�W�����ł����삷��\���͂���܂��B
+バージョンはLittleSLAMの開発で使用したものであり、明確な条件ではありません。
+これ以上のバージョンであれば通常は動作します。
+これ以下のバージョンでも動作する可能性はあります。
 
-## �g����
+## 使い方
 
-- Windows�ł̎g������[������](doc/install-win.md)
+- Windowsでの使い方は[こちら](doc/install-win.md)
 
-- Linux�ł̎g������[������](doc/install-linux.md)
+- Linuxでの使い方は[こちら](doc/install-linux.md)
 
-## �f�[�^�Z�b�g
+## データセット
 
-�����p��6�̃f�[�^�t�@�C����p�ӂ��Ă��܂��B���\�Ɉꗗ�������܂��B
-[����](https://furo.org/software/little_slam/dataset.zip)����_�E�����[�h�ł��܂��B
+実験用に6個のデータファイルを用意しています。下表に一覧を示します。
+[ここ](https://furo.org/software/little_slam/dataset.zip)からダウンロードできます。
 
 
-| �t�@�C����          | ���e         |
+| ファイル名          | 内容         |
 |:--------------------|:-------------|
-| corridor.lsc        | �L���i�P�ꃋ�[�v�j |
-| hall.lsc            | �L�ԁi�P�ꃋ�[�v�j |
-| corridor-degene.lsc | �L���i�މ��j |
-| hall-degene.lsc     | �L�ԁi�މ��j |
-| corridor-loops.lsc  | �L���i���d���[�v�j |
-| hall-loops.lsc      | �L�ԁi���d���[�v�j |
+| corridor.lsc        | 廊下（単一ループ） |
+| hall.lsc            | 広間（単一ループ） |
+| corridor-degene.lsc | 廊下（退化） |
+| hall-degene.lsc     | 広間（退化） |
+| corridor-loops.lsc  | 廊下（多重ループ） |
+| hall-loops.lsc      | 広間（多重ループ） |
 
-## �J�X�^�}�C�Y
+## カスタマイズ
 
-LittleSLAM�͊w�K�p�v���O�����ł���A��{�`���炢�����̉��ǂ��o��
-��������悤�ɃJ�X�^�}�C�Y�ł��܂��B  
-�ڍׂ�[������](doc/customize.md)���Q�Ƃ��Ă��������B
+LittleSLAMは学習用プログラムであり、基本形からいくつかの改良を経て
+完成するようにカスタマイズできます。  
+詳細は[こちら](doc/customize.md)を参照してください。
 
-## �Q�l����
+## 参考書籍
 
-���L�̏��Ђ�SLAM�̉�����ł��BSLAM�̈�ʓI�ȉ��������ƂƂ��ɁA
-��̗�Ƃ���LittleSLAM�����ނɗp���A���̃\�[�X�R�[�h�̏ڍׂ�������Ă��܂��B
+下記の書籍はSLAMの解説書です。SLAMの一般的な解説をするとともに、
+具体例としてLittleSLAMを教材に用い、そのソースコードの詳細を説明しています。
 
-[1] �F�[���T�A�uSLAM���� -- ���{�b�g�̎��Ȉʒu����ƒn�}�\�z�̋Z�p�v�A�I�[���ЁA2018�N  
+[1] 友納正裕、「SLAM入門 -- ロボットの自己位置推定と地図構築の技術」、オーム社、2018年  
 
-## ���C�Z���X
+## ライセンス
 
-- LittleSLAM�́AMPL-2.0���C�Z���X�ɂ��ƂÂ��Ă��܂��B
+- LittleSLAMは、MPL-2.0ライセンスにもとづいています。
 

--- a/cui/CMakeLists.txt
+++ b/cui/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(cui)
+﻿project(cui)
 
 cmake_minimum_required(VERSION 2.8)
 

--- a/cui/FrameworkCustomizer.cpp
+++ b/cui/FrameworkCustomizer.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,12 +16,12 @@
 
 using namespace std;
 
-// ƒtƒŒ[ƒ€ƒ[ƒN‚ÌŠî–{•”•ª‚ğİ’è
+// ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ã®åŸºæœ¬éƒ¨åˆ†ã‚’è¨­å®š
 void FrameworkCustomizer::makeFramework() {
   smat.setPoseEstimator(&poest);
   smat.setPoseFuser(&pfu);
 
-  // LoopDetectorSS‚Íg‚¤•”•i‚ªŒˆ‚Ü‚Á‚Ä‚¢‚é‚Ì‚ÅA‚±‚±‚Å“ü‚ê‚é
+  // LoopDetectorSSã¯ä½¿ã†éƒ¨å“ãŒæ±ºã¾ã£ã¦ã„ã‚‹ã®ã§ã€ã“ã“ã§å…¥ã‚Œã‚‹
   lpdSS.setPoseEstimator(&poest);
   lpdSS.setPoseFuser(&pfu);
   lpdSS.setDataAssociator(&dassGT);
@@ -31,16 +31,16 @@ void FrameworkCustomizer::makeFramework() {
   sfront->setScanMatcher(&smat);
 }
 
-/////// ÀŒ±—p
+/////// å®Ÿé¨“ç”¨
 
-// ƒtƒŒ[ƒ€ƒ[ƒNŠî–{\¬
+// ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯åŸºæœ¬æ§‹æˆ
 void FrameworkCustomizer::customizeA() {
-  pcmap = &pcmapBS;                                // ‘SƒXƒLƒƒƒ““_‚ğ•Û‘¶‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmBS;                      // ’¼‘OƒXƒLƒƒƒ“‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassLS;                  // üŒ`’Tõ‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncED;                  // ƒ†[ƒNƒŠƒbƒh‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSD;                   // Å‹}~‰º–@‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapBS;                                // å…¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã‚’ä¿å­˜ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmBS;                      // ç›´å‰ã‚¹ã‚­ãƒ£ãƒ³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassLS;                  // ç·šå½¢æ¢ç´¢ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncED;                  // ãƒ¦ãƒ¼ã‚¯ãƒªãƒƒãƒ‰è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSD;                   // æœ€æ€¥é™ä¸‹æ³•ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -50,17 +50,17 @@ void FrameworkCustomizer::customizeA() {
   smat.setRefScanMaker(rsm);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// Šiqƒe[ƒuƒ‹‚Ì—˜—p
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã®åˆ©ç”¨
 void FrameworkCustomizer::customizeB() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassLS;                  // üŒ`’Tõ‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncED;                  // ƒ†[ƒNƒŠƒbƒh‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSD;                   // Å‹}~‰º–@‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassLS;                  // ç·šå½¢æ¢ç´¢ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncED;                  // ãƒ¦ãƒ¼ã‚¯ãƒªãƒƒãƒ‰è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSD;                   // æœ€æ€¥é™ä¸‹æ³•ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -70,17 +70,17 @@ void FrameworkCustomizer::customizeB() {
   smat.setRefScanMaker(rsm);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// Å‹}~‰º–@‚ÌŒã‚É’¼ü’Tõ‚ğs‚¤
+// æœ€æ€¥é™ä¸‹æ³•ã®å¾Œã«ç›´ç·šæ¢ç´¢ã‚’è¡Œã†
 void FrameworkCustomizer::customizeC() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassLS;                  // üŒ`’Tõ‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncED;                  // ƒ†[ƒNƒŠƒbƒh‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassLS;                  // ç·šå½¢æ¢ç´¢ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncED;                  // ãƒ¦ãƒ¼ã‚¯ãƒªãƒƒãƒ‰è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -90,17 +90,17 @@ void FrameworkCustomizer::customizeC() {
   smat.setRefScanMaker(rsm);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// ƒf[ƒ^‘Î‰‚Ã‚¯‚ğŠiqƒe[ƒuƒ‹‚Ås‚¤
+// ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘ã‚’æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§è¡Œã†
 void FrameworkCustomizer::customizeD() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncED;                  // ƒ†[ƒNƒŠƒbƒh‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncED;                  // ãƒ¦ãƒ¼ã‚¯ãƒªãƒƒãƒ‰è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -110,17 +110,17 @@ void FrameworkCustomizer::customizeD() {
   smat.setRefScanMaker(rsm);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// ƒXƒLƒƒƒ““_ŠÔŠu‹Ïˆê‰»‚ğ’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”å‡ä¸€åŒ–ã‚’è¿½åŠ 
 void FrameworkCustomizer::customizeE() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncED;                  // ƒ†[ƒNƒŠƒbƒh‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncED;                  // ãƒ¦ãƒ¼ã‚¯ãƒªãƒƒãƒ‰è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -128,20 +128,20 @@ void FrameworkCustomizer::customizeE() {
   pfu.setDataAssociator(dass);
   smat.setPointCloudMap(pcmap);
   smat.setRefScanMaker(rsm);
-  smat.setScanPointResampler(&spres);              // ƒXƒLƒƒƒ““_ŠÔŠu‹Ïˆê‰»
+  smat.setScanPointResampler(&spres);              // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”å‡ä¸€åŒ–
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// ƒXƒLƒƒƒ““_‚Ì–@üŒvZ‚ğ’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ³•ç·šè¨ˆç®—ã‚’è¿½åŠ 
 void FrameworkCustomizer::customizeF() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncPD;                  // ‚’¼‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncPD;                  // å‚ç›´è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -149,20 +149,20 @@ void FrameworkCustomizer::customizeF() {
   pfu.setDataAssociator(dass);
   smat.setPointCloudMap(pcmap);
   smat.setRefScanMaker(rsm);
-  smat.setScanPointAnalyser(&spana);               // ƒXƒLƒƒƒ““_‚Ì–@üŒvZ
+  smat.setScanPointAnalyser(&spana);               // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ³•ç·šè¨ˆç®—
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// ƒXƒLƒƒƒ““_ŠÔŠu‹Ïˆê‰»‚Æ–@üŒvZ‚ğ’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”å‡ä¸€åŒ–ã¨æ³•ç·šè¨ˆç®—ã‚’è¿½åŠ 
 void FrameworkCustomizer::customizeG() {
-  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncPD;                  // ‚’¼‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncPD;                  // å‚ç›´è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -170,22 +170,22 @@ void FrameworkCustomizer::customizeG() {
   pfu.setDataAssociator(dass);
   smat.setPointCloudMap(pcmap);
   smat.setRefScanMaker(rsm);
-  smat.setScanPointResampler(&spres);              // ƒXƒLƒƒƒ““_ŠÔŠu‹Ïˆê‰»
-  smat.setScanPointAnalyser(&spana);               // ƒXƒLƒƒƒ““_‚Ì–@üŒvZ
+  smat.setScanPointResampler(&spres);              // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”å‡ä¸€åŒ–
+  smat.setScanPointAnalyser(&spana);               // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ³•ç·šè¨ˆç®—
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(false);                       // ƒZƒ“ƒT—Z‡‚µ‚È‚¢
+  sfront->setDgCheck(false);                       // ã‚»ãƒ³ã‚µèåˆã—ãªã„
 }
 
-// ƒZƒ“ƒT—Z‡‚ğ’Ç‰Á
+// ã‚»ãƒ³ã‚µèåˆã‚’è¿½åŠ 
 void FrameworkCustomizer::customizeH() {
-//  pcmap = &pcmapGT;                                // Šiqƒe[ƒuƒ‹‚ÅŠÇ—‚·‚é“_ŒQ’n}
-  pcmap = &pcmapLP;                                // •”•ª’n}‚²‚Æ‚ÉŠÇ—‚·‚é“_ŒQ’n}BcI‚Æ‚Ì”äŠr—p
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncPD;                  // ‚’¼‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdDM;                      // ƒ_ƒ~[‚Ìƒ‹[ƒvŒŸo
+//  pcmap = &pcmapGT;                                // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã§ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  pcmap = &pcmapLP;                                // éƒ¨åˆ†åœ°å›³ã”ã¨ã«ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³ã€‚cIã¨ã®æ¯”è¼ƒç”¨
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncPD;                  // å‚ç›´è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdDM;                      // ãƒ€ãƒŸãƒ¼ã®ãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -197,17 +197,17 @@ void FrameworkCustomizer::customizeH() {
   smat.setScanPointAnalyser(&spana);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(true);                        // ƒZƒ“ƒT—Z‡‚·‚é
+  sfront->setDgCheck(true);                        // ã‚»ãƒ³ã‚µèåˆã™ã‚‹
 }
 
-// ƒZƒ“ƒT—Z‡‚Æƒ‹[ƒv•Â‚¶‚İ‚ğ’Ç‰Á
+// ã‚»ãƒ³ã‚µèåˆã¨ãƒ«ãƒ¼ãƒ—é–‰ã˜è¾¼ã¿ã‚’è¿½åŠ 
 void FrameworkCustomizer::customizeI() {
-  pcmap = &pcmapLP;                                // •”•ª’n}‚²‚Æ‚ÉŠÇ—‚·‚é“_ŒQ’n}
-  RefScanMaker *rsm = &rsmLM;                      // ‹ÇŠ’n}‚ğQÆƒXƒLƒƒƒ“‚Æ‚·‚é
-  DataAssociator *dass = &dassGT;                  // Šiqƒe[ƒuƒ‹‚É‚æ‚éƒf[ƒ^‘Î‰‚Ã‚¯
-  CostFunction *cfunc = &cfuncPD;                  // ‚’¼‹——£‚ğƒRƒXƒgŠÖ”‚Æ‚·‚é
-  PoseOptimizer *popt = &poptSL;                   // Å‹}~‰º–@‚Æ’¼ü’Tõ‚É‚æ‚éÅ“K‰»
-  LoopDetector *lpd = &lpdSS;                      // •”•ª’n}‚ğ—p‚¢‚½ƒ‹[ƒvŒŸo
+  pcmap = &pcmapLP;                                // éƒ¨åˆ†åœ°å›³ã”ã¨ã«ç®¡ç†ã™ã‚‹ç‚¹ç¾¤åœ°å›³
+  RefScanMaker *rsm = &rsmLM;                      // å±€æ‰€åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã¨ã™ã‚‹
+  DataAssociator *dass = &dassGT;                  // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚‹ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
+  CostFunction *cfunc = &cfuncPD;                  // å‚ç›´è·é›¢ã‚’ã‚³ã‚¹ãƒˆé–¢æ•°ã¨ã™ã‚‹
+  PoseOptimizer *popt = &poptSL;                   // æœ€æ€¥é™ä¸‹æ³•ã¨ç›´ç·šæ¢ç´¢ã«ã‚ˆã‚‹æœ€é©åŒ–
+  LoopDetector *lpd = &lpdSS;                      // éƒ¨åˆ†åœ°å›³ã‚’ç”¨ã„ãŸãƒ«ãƒ¼ãƒ—æ¤œå‡º
 
   popt->setCostFunction(cfunc);
   poest.setDataAssociator(dass);
@@ -219,5 +219,5 @@ void FrameworkCustomizer::customizeI() {
   smat.setScanPointAnalyser(&spana);
   sfront->setLoopDetector(lpd);
   sfront->setPointCloudMap(pcmap);
-  sfront->setDgCheck(true);                        // ƒZƒ“ƒT—Z‡‚·‚é
+  sfront->setDgCheck(true);                        // ã‚»ãƒ³ã‚µèåˆã™ã‚‹
 }

--- a/cui/FrameworkCustomizer.h
+++ b/cui/FrameworkCustomizer.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -44,7 +44,7 @@
 
 class FrameworkCustomizer
 {
-  // ƒtƒŒ[ƒ€ƒ[ƒN‰ü‘¢—p‚Ì•”•i
+  // ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯æ”¹é€ ç”¨ã®éƒ¨å“
   RefScanMakerBS rsmBS;
   RefScanMakerLM rsmLM;
   DataAssociatorLS dassLS;
@@ -56,8 +56,8 @@ class FrameworkCustomizer
   PointCloudMapBS pcmapBS;
   PointCloudMapGT pcmapGT;
   PointCloudMapLP pcmapLP;
-  PointCloudMap *pcmap;            // SlamLauncher‚ÅQÆ‚·‚é‚½‚ßƒƒ“ƒo•Ï”‚É‚·‚é
-  LoopDetector lpdDM;              // ƒ_ƒ~[B‰½‚à‚µ‚È‚¢
+  PointCloudMap *pcmap;            // SlamLauncherã§å‚ç…§ã™ã‚‹ãŸã‚ãƒ¡ãƒ³ãƒå¤‰æ•°ã«ã™ã‚‹
+  LoopDetector lpdDM;              // ãƒ€ãƒŸãƒ¼ã€‚ä½•ã‚‚ã—ãªã„
   LoopDetectorSS lpdSS;
   ScanPointResampler spres;
   ScanPointAnalyser spana;

--- a/cui/MapDrawer.cpp
+++ b/cui/MapDrawer.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,61 +16,61 @@
 
 using namespace std;
 
-////////// Gnuplot‚É‚æ‚é’n}•`‰æ //////////
+////////// Gnuplotã«ã‚ˆã‚‹åœ°å›³æç”» //////////
 
-// ’n}‚Æ‹OÕ‚ğ•`‰æ
+// åœ°å›³ã¨è»Œè·¡ã‚’æç”»
 void MapDrawer::drawMapGp(const PointCloudMap &pcmap) {
-  const vector<LPoint2D> &lps = pcmap.globalMap;         // ’n}‚Ì“_ŒQ
-  const vector<Pose2D> &poses = pcmap.poses;             // ƒƒ{ƒbƒg‹OÕ
+  const vector<LPoint2D> &lps = pcmap.globalMap;         // åœ°å›³ã®ç‚¹ç¾¤
+  const vector<Pose2D> &poses = pcmap.poses;             // ãƒ­ãƒœãƒƒãƒˆè»Œè·¡
   drawGp(lps, poses);
 }
 
-// ƒXƒLƒƒƒ“1ŒÂ‚ğ•`‰æ
+// ã‚¹ã‚­ãƒ£ãƒ³1å€‹ã‚’æç”»
 void MapDrawer::drawScanGp(const Scan2D &scan) {
   vector<Pose2D> poses;
-  Pose2D pose;                   // Œ´“_
-  poses.emplace_back(pose);      // drawGp‚ğg‚¤‚½‚ß‚Évector‚É“ü‚ê‚é
+  Pose2D pose;                   // åŸç‚¹
+  poses.emplace_back(pose);      // drawGpã‚’ä½¿ã†ãŸã‚ã«vectorã«å…¥ã‚Œã‚‹
   drawGp(scan.lps, poses);
 }
 
-// ƒƒ{ƒbƒg‹OÕ‚¾‚¯‚ğ•`‰æ
+// ãƒ­ãƒœãƒƒãƒˆè»Œè·¡ã ã‘ã‚’æç”»
 void MapDrawer::drawTrajectoryGp(const vector<Pose2D> &poses) {
-  vector<LPoint2D> lps;          // drawGp‚ğg‚¤‚½‚ß‚Ìƒ_ƒ~[i‹ój
+  vector<LPoint2D> lps;          // drawGpã‚’ä½¿ã†ãŸã‚ã®ãƒ€ãƒŸãƒ¼ï¼ˆç©ºï¼‰
   drawGp(lps, poses);
 }
 
 //////////
 
 void MapDrawer::drawGp(const vector<LPoint2D> &lps, const vector<Pose2D> &poses, bool flush) {
-  printf("drawGp: lps.size=%lu\n", lps.size());     // “_”‚ÌŠm”F—p
+  printf("drawGp: lps.size=%lu\n", lps.size());     // ç‚¹æ•°ã®ç¢ºèªç”¨
 
-  // gnuplotİ’è
+  // gnuplotè¨­å®š
   fprintf(gp, "set multiplot\n");
 //  fprintf(gp, "plot '-' w p pt 7 ps 0.1, '-' with vector\n");
   fprintf(gp, "plot '-' w p pt 7 ps 0.1 lc rgb 0x0, '-' with vector\n");
 
-  // “_ŒQ‚Ì•`‰æ
-  int step1=1;                  // “_‚ÌŠÔˆø‚«ŠÔŠuB•`‰æ‚ªd‚¢‚Æ‚«‘å‚«‚­‚·‚é
+  // ç‚¹ç¾¤ã®æç”»
+  int step1=1;                  // ç‚¹ã®é–“å¼•ãé–“éš”ã€‚æç”»ãŒé‡ã„ã¨ãå¤§ããã™ã‚‹
   for (size_t i=0; i<lps.size(); i+=step1) {
     const LPoint2D &lp = lps[i];
-    fprintf(gp, "%lf %lf\n", lp.x, lp.y);    // “_‚Ì•`‰æ
+    fprintf(gp, "%lf %lf\n", lp.x, lp.y);    // ç‚¹ã®æç”»
   }
   fprintf(gp, "e\n");
 
-  // ƒƒ{ƒbƒg‹OÕ‚Ì•`‰æ
-  int step2=10;                      // ƒƒ{ƒbƒgˆÊ’u‚ÌŠÔˆø‚«ŠÔŠu
+  // ãƒ­ãƒœãƒƒãƒˆè»Œè·¡ã®æç”»
+  int step2=10;                      // ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®é–“å¼•ãé–“éš”
   for (size_t i=0; i<poses.size(); i+=step2) {
     const Pose2D &pose = poses[i];
-    double cx = pose.tx;             // •ÀiˆÊ’u
+    double cx = pose.tx;             // ä¸¦é€²ä½ç½®
     double cy = pose.ty;
-    double cs = pose.Rmat[0][0];     // ‰ñ“]Šp‚É‚æ‚écos
-    double sn = pose.Rmat[1][0];     // ‰ñ“]Šp‚É‚æ‚ésin
+    double cs = pose.Rmat[0][0];     // å›è»¢è§’ã«ã‚ˆã‚‹cos
+    double sn = pose.Rmat[1][0];     // å›è»¢è§’ã«ã‚ˆã‚‹sin
 
-    // ƒƒ{ƒbƒgÀ•WŒn‚ÌˆÊ’u‚ÆŒü‚«‚ğ•`‚­
+    // ãƒ­ãƒœãƒƒãƒˆåº§æ¨™ç³»ã®ä½ç½®ã¨å‘ãã‚’æã
     double dd = 0.4;
-    double x1 = cs*dd;              // ƒƒ{ƒbƒgÀ•WŒn‚Ìx²
+    double x1 = cs*dd;              // ãƒ­ãƒœãƒƒãƒˆåº§æ¨™ç³»ã®xè»¸
     double y1 = sn*dd;
-    double x2 = -sn*dd;             // ƒƒ{ƒbƒgÀ•WŒn‚Ìy²
+    double x2 = -sn*dd;             // ãƒ­ãƒœãƒƒãƒˆåº§æ¨™ç³»ã®yè»¸
     double y2 = cs*dd;
     fprintf(gp, "%lf %lf %lf %lf\n", cx, cy, x1, y1);
     fprintf(gp, "%lf %lf %lf %lf\n", cx, cy, x2, y2);
@@ -78,5 +78,5 @@ void MapDrawer::drawGp(const vector<LPoint2D> &lps, const vector<Pose2D> &poses,
   fprintf(gp, "e\n");
 
   if (flush)
-    fflush(gp);         // ƒoƒbƒtƒ@‚Ìƒf[ƒ^‚ğ‘‚«o‚·B‚±‚ê‚µ‚È‚¢‚Æ•`‰æ‚ª‚æ‚­‚È‚¢
+    fflush(gp);         // ãƒãƒƒãƒ•ã‚¡ã®ãƒ‡ãƒ¼ã‚¿ã‚’æ›¸ãå‡ºã™ã€‚ã“ã‚Œã—ãªã„ã¨æç”»ãŒã‚ˆããªã„
 }

--- a/cui/MapDrawer.h
+++ b/cui/MapDrawer.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -23,12 +23,12 @@
 class MapDrawer
 {
 private:
-  FILE *gp;               // gnuplot‚Ö‚ÌƒpƒCƒv
-  double xmin;            // •`‰æ”ÍˆÍ[m]
+  FILE *gp;               // gnuplotã¸ã®ãƒ‘ã‚¤ãƒ—
+  double xmin;            // æç”»ç¯„å›²[m]
   double xmax;
   double ymin;
   double ymax;
-  double aspectR;         // xy”ä
+  double aspectR;         // xyæ¯”
 
 public:
   MapDrawer() : gp(nullptr), xmin(-10), xmax(10), ymin(-10), ymax(10), aspectR(-1.0) {
@@ -42,9 +42,9 @@ public:
 
   void initGnuplot() {
 #ifdef _WIN32
-    gp = _popen("gnuplot", "w");      // ƒpƒCƒvƒI[ƒvƒ“.Windows
+    gp = _popen("gnuplot", "w");      // ãƒ‘ã‚¤ãƒ—ã‚ªãƒ¼ãƒ—ãƒ³.Windows
 #elif __linux__
-    gp = popen("gnuplot", "w");       // ƒpƒCƒvƒI[ƒvƒ“.Linux
+    gp = popen("gnuplot", "w");       // ãƒ‘ã‚¤ãƒ—ã‚ªãƒ¼ãƒ—ãƒ³.Linux
 #endif
   }
 
@@ -62,14 +62,14 @@ public:
     fprintf(gp, "set size ratio %lf\n", aspectR);
   }
 
-  void setRange(double R) {              // •`‰æ”ÍˆÍ‚ğRl•û‚É‚·‚é
+  void setRange(double R) {              // æç”»ç¯„å›²ã‚’Rå››æ–¹ã«ã™ã‚‹
     xmin = ymin = -R;
     xmax = ymax = R;
     fprintf(gp, "set xrange [%lf:%lf]\n", xmin, xmax);
     fprintf(gp, "set yrange [%lf:%lf]\n", ymin, ymax);
   }
 
-  void setRange(double xR, double yR) {  // •`‰æ”ÍˆÍ‚ğ}xRA}yR‚É‚·‚é
+  void setRange(double xR, double yR) {  // æç”»ç¯„å›²ã‚’Â±xRã€Â±yRã«ã™ã‚‹
     xmin = -xR;
     xmax = xR;
     ymin = -yR; 
@@ -78,7 +78,7 @@ public:
     fprintf(gp, "set yrange [%lf:%lf]\n", ymin, ymax);
   }
 
-  void setRange(double xm, double xM, double ym, double yM) {  // •`‰æ”ÍˆÍ‚ğ‘S•”w’è
+  void setRange(double xm, double xM, double ym, double yM) {  // æç”»ç¯„å›²ã‚’å…¨éƒ¨æŒ‡å®š
     xmin = xm;
     xmax = xM;
     ymin = ym; 

--- a/cui/SlamLauncher.cpp
+++ b/cui/SlamLauncher.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,24 +17,24 @@
 #include "SlamLauncher.h"
 #include "ScanPointResampler.h"
 
-using namespace std;                       // C++•W€ƒ‰ƒCƒuƒ‰ƒŠ‚Ì–¼‘O‹óŠÔ‚ğg‚¤
+using namespace std;                       // C++æ¨™æº–ãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®åå‰ç©ºé–“ã‚’ä½¿ã†
 
 //////////
 
 void SlamLauncher::run() {
-  mdrawer.initGnuplot();                   // gnuplot‰Šú‰»
-  mdrawer.setAspectRatio(-0.9);            // x²‚Æy²‚Ì”äi•‰‚É‚·‚é‚Æ’†g‚ªˆê’èj
+  mdrawer.initGnuplot();                   // gnuplotåˆæœŸåŒ–
+  mdrawer.setAspectRatio(-0.9);            // xè»¸ã¨yè»¸ã®æ¯”ï¼ˆè² ã«ã™ã‚‹ã¨ä¸­èº«ãŒä¸€å®šï¼‰
   
-  size_t cnt = 0;                          // ˆ—‚Ì˜_—
+  size_t cnt = 0;                          // å‡¦ç†ã®è«–ç†æ™‚åˆ»
   if (startN > 0)
-    skipData(startN);                      // startN‚Ü‚Åƒf[ƒ^‚ğ“Ç‚İ”ò‚Î‚·
+    skipData(startN);                      // startNã¾ã§ãƒ‡ãƒ¼ã‚¿ã‚’èª­ã¿é£›ã°ã™
 
   double totalTime=0, totalTimeDraw=0, totalTimeRead=0;
   Scan2D scan;
-  bool eof = sreader.loadScan(cnt, scan);  // ƒtƒ@ƒCƒ‹‚©‚çƒXƒLƒƒƒ“‚ğ1ŒÂ“Ç‚İ‚Ş
+  bool eof = sreader.loadScan(cnt, scan);  // ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã‚¹ã‚­ãƒ£ãƒ³ã‚’1å€‹èª­ã¿è¾¼ã‚€
   boost::timer tim;
   while(!eof) {
-    if (odometryOnly) {                      // ƒIƒhƒƒgƒŠ‚É‚æ‚é’n}\’ziSLAM‚æ‚è—Dæj
+    if (odometryOnly) {                      // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰ï¼ˆSLAMã‚ˆã‚Šå„ªå…ˆï¼‰
       if (cnt == 0) {
         ipose = scan.pose;
         ipose.calRmat();
@@ -42,22 +42,22 @@ void SlamLauncher::run() {
       mapByOdometry(&scan);
     }
     else 
-      sfront.process(scan);                // SLAM‚É‚æ‚é’n}\’z
+      sfront.process(scan);                // SLAMã«ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰
 
     double t1 = 1000*tim.elapsed();
 
-    if (cnt%drawSkip == 0) {               // drawSkip‚¨‚«‚ÉŒ‹‰Ê‚ğ•`‰æ
+    if (cnt%drawSkip == 0) {               // drawSkipãŠãã«çµæœã‚’æç”»
       mdrawer.drawMapGp(*pcmap);
     }
     double t2 = 1000*tim.elapsed();
 
-    ++cnt;                                 // ˜_—XV
-    eof = sreader.loadScan(cnt, scan);     // Ÿ‚ÌƒXƒLƒƒƒ“‚ğ“Ç‚İ‚Ş
+    ++cnt;                                 // è«–ç†æ™‚åˆ»æ›´æ–°
+    eof = sreader.loadScan(cnt, scan);     // æ¬¡ã®ã‚¹ã‚­ãƒ£ãƒ³ã‚’èª­ã¿è¾¼ã‚€
 
     double t3 = 1000*tim.elapsed();
-    totalTime = t3;                        // ‘S‘Ìˆ—ŠÔ
-    totalTimeDraw += (t2-t1);              // •`‰æŠÔ‚Ì‡Œv
-    totalTimeRead += (t3-t2);              // ƒ[ƒhŠÔ‚Ì‡Œv
+    totalTime = t3;                        // å…¨ä½“å‡¦ç†æ™‚é–“
+    totalTimeDraw += (t2-t1);              // æç”»æ™‚é–“ã®åˆè¨ˆ
+    totalTimeRead += (t3-t2);              // ãƒ­ãƒ¼ãƒ‰æ™‚é–“ã®åˆè¨ˆ
 
     printf("---- SlamLauncher: cnt=%lu ends ----\n", cnt);
   }
@@ -66,41 +66,41 @@ void SlamLauncher::run() {
   printf("Elapsed time: mapping=%g, drawing=%g, reading=%g\n", (totalTime-totalTimeDraw-totalTimeRead), totalTimeDraw, totalTimeRead);
   printf("SlamLauncher finished.\n");
 
-  // ˆ—I—¹Œã‚à•`‰æ‰æ–Ê‚ğc‚·‚½‚ß‚Ésleep‚Å–³ŒÀƒ‹[ƒv‚É‚·‚éBctrl-C‚ÅI—¹B
+  // å‡¦ç†çµ‚äº†å¾Œã‚‚æç”»ç”»é¢ã‚’æ®‹ã™ãŸã‚ã«sleepã§ç„¡é™ãƒ«ãƒ¼ãƒ—ã«ã™ã‚‹ã€‚ctrl-Cã§çµ‚äº†ã€‚
   while(true) {
 #ifdef _WIN32
-    Sleep(1000);                            // Windows‚Å‚ÍSleep
+    Sleep(1000);                            // Windowsã§ã¯Sleep
 #elif __linux__
-    usleep(1000000);                        // Linux‚Å‚Íusleep
+    usleep(1000000);                        // Linuxã§ã¯usleep
 #endif
   }
 }
 
-// ŠJn‚©‚çnumŒÂ‚ÌƒXƒLƒƒƒ“‚Ü‚Å“Ç‚İ”ò‚Î‚·
+// é–‹å§‹ã‹ã‚‰numå€‹ã®ã‚¹ã‚­ãƒ£ãƒ³ã¾ã§èª­ã¿é£›ã°ã™
 void SlamLauncher::skipData(int num) {
   Scan2D scan;
   bool eof = sreader.loadScan(0, scan);
-  for (int i=0; !eof && i<num; i++) {       // numŒÂ‹ó“Ç‚İ‚·‚é
+  for (int i=0; !eof && i<num; i++) {       // numå€‹ç©ºèª­ã¿ã™ã‚‹
     eof = sreader.loadScan(0, scan);
   }
 }
 
-///////// ƒIƒhƒƒgƒŠ‚Ì‚æ‚é’n}\’z //////////
+///////// ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰ //////////
 
 void SlamLauncher::mapByOdometry(Scan2D *scan) {
-//  Pose2D &pose = scan->pose;               // ƒXƒLƒƒƒ“æ“¾‚ÌƒIƒhƒƒgƒŠˆÊ’u
+//  Pose2D &pose = scan->pose;               // ã‚¹ã‚­ãƒ£ãƒ³å–å¾—æ™‚ã®ã‚ªãƒ‰ãƒ¡ãƒˆãƒªä½ç½®
   Pose2D pose;
   Pose2D::calRelativePose(scan->pose, ipose, pose);
-  vector<LPoint2D> &lps = scan->lps;       // ƒXƒLƒƒƒ““_ŒQ
-  vector<LPoint2D> glps;                   // ’n}À•WŒn‚Å‚Ì“_ŒQ
+  vector<LPoint2D> &lps = scan->lps;       // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
+  vector<LPoint2D> glps;                   // åœ°å›³åº§æ¨™ç³»ã§ã®ç‚¹ç¾¤
   for (size_t j=0; j<lps.size(); j++) {
     LPoint2D &lp = lps[j];
     LPoint2D glp;
-    pose.globalPoint(lp, glp);             // ƒZƒ“ƒTÀ•WŒn‚©‚ç’n}À•WŒn‚É•ÏŠ·
+    pose.globalPoint(lp, glp);             // ã‚»ãƒ³ã‚µåº§æ¨™ç³»ã‹ã‚‰åœ°å›³åº§æ¨™ç³»ã«å¤‰æ›
     glps.emplace_back(glp);
   }
 
-  // “_ŒQ’n}pcmap‚Éƒf[ƒ^‚ğŠi”[
+  // ç‚¹ç¾¤åœ°å›³pcmapã«ãƒ‡ãƒ¼ã‚¿ã‚’æ ¼ç´
   pcmap->addPose(pose);
   pcmap->addPoints(glps);
   pcmap->makeGlobalMap();
@@ -108,32 +108,32 @@ void SlamLauncher::mapByOdometry(Scan2D *scan) {
   printf("Odom pose: tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);
 }
 
-////////// ƒXƒLƒƒƒ“•`‰æ ////////
+////////// ã‚¹ã‚­ãƒ£ãƒ³æç”» ////////
 
 void SlamLauncher::showScans() {
   mdrawer.initGnuplot();
-  mdrawer.setRange(6);                     // •`‰æ”ÍˆÍBƒXƒLƒƒƒ“‚ª6ml•û‚Ìê‡
-  mdrawer.setAspectRatio(-0.9);            // x²‚Æy²‚Ì”äi•‰‚É‚·‚é‚Æ’†g‚ªˆê’èj
+  mdrawer.setRange(6);                     // æç”»ç¯„å›²ã€‚ã‚¹ã‚­ãƒ£ãƒ³ãŒ6må››æ–¹ã®å ´åˆ
+  mdrawer.setAspectRatio(-0.9);            // xè»¸ã¨yè»¸ã®æ¯”ï¼ˆè² ã«ã™ã‚‹ã¨ä¸­èº«ãŒä¸€å®šï¼‰
 
   ScanPointResampler spres;
 
-  size_t cnt = 0;                          // ˆ—‚Ì˜_—
+  size_t cnt = 0;                          // å‡¦ç†ã®è«–ç†æ™‚åˆ»
   if (startN > 0)
-    skipData(startN);                      // startN‚Ü‚Åƒf[ƒ^‚ğ“Ç‚İ”ò‚Î‚·
+    skipData(startN);                      // startNã¾ã§ãƒ‡ãƒ¼ã‚¿ã‚’èª­ã¿é£›ã°ã™
 
   Scan2D scan;
   bool eof = sreader.loadScan(cnt, scan);
   while(!eof) {
-//    spres.resamplePoints(&scan);         // ƒRƒƒ“ƒgƒAƒEƒg‚Í‚¸‚¹‚ÎAƒXƒLƒƒƒ““_ŠÔŠu‚ğ‹Ïˆê‚É‚·‚éB
+//    spres.resamplePoints(&scan);         // ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã¯ãšã›ã°ã€ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”ã‚’å‡ä¸€ã«ã™ã‚‹ã€‚
  
-    // •`‰æŠÔŠu‚ğ‚ ‚¯‚é
+    // æç”»é–“éš”ã‚’ã‚ã‘ã‚‹
 #ifdef _WIN32
-    Sleep(100);                            // Windows‚Å‚ÍSleep
+    Sleep(100);                            // Windowsã§ã¯Sleep
 #elif __linux__
-    usleep(100000);                        // Linux‚Å‚Íusleep
+    usleep(100000);                        // Linuxã§ã¯usleep
 #endif
 
-    mdrawer.drawScanGp(scan);              // ƒXƒLƒƒƒ“•`‰æ
+    mdrawer.drawScanGp(scan);              // ã‚¹ã‚­ãƒ£ãƒ³æç”»
 
     printf("---- scan num=%lu ----\n", cnt);
     eof = sreader.loadScan(cnt, scan);
@@ -143,10 +143,10 @@ void SlamLauncher::showScans() {
   printf("SlamLauncher finished.\n");
 }
 
-//////// ƒXƒLƒƒƒ““Ç‚İ‚İ /////////
+//////// ã‚¹ã‚­ãƒ£ãƒ³èª­ã¿è¾¼ã¿ /////////
 
 bool SlamLauncher::setFilename(char *filename) {
-  bool flag = sreader.openScanFile(filename);        // ƒtƒ@ƒCƒ‹‚ğƒI[ƒvƒ“
+  bool flag = sreader.openScanFile(filename);        // ãƒ•ã‚¡ã‚¤ãƒ«ã‚’ã‚ªãƒ¼ãƒ—ãƒ³
 
   return(flag);
 }
@@ -156,9 +156,9 @@ bool SlamLauncher::setFilename(char *filename) {
 void SlamLauncher::customizeFramework() {
   fcustom.setSlamFrontEnd(&sfront);
   fcustom.makeFramework();
-//  fcustom.customizeG();                         // ‘Ş‰»‚Ì‘Îˆ‚ğ‚µ‚È‚¢
-//  fcustom.customizeH();                         // ‘Ş‰»‚Ì‘Îˆ‚ğ‚·‚é
-  fcustom.customizeI();                           // ƒ‹[ƒv•Â‚¶‚İ‚ğ‚·‚é
+//  fcustom.customizeG();                         // é€€åŒ–ã®å¯¾å‡¦ã‚’ã—ãªã„
+//  fcustom.customizeH();                         // é€€åŒ–ã®å¯¾å‡¦ã‚’ã™ã‚‹
+  fcustom.customizeI();                           // ãƒ«ãƒ¼ãƒ—é–‰ã˜è¾¼ã¿ã‚’ã™ã‚‹
 
-  pcmap = fcustom.getPointCloudMap();           // customize‚ÌŒã‚É‚â‚é‚±‚Æ
+  pcmap = fcustom.getPointCloudMap();           // customizeã®å¾Œã«ã‚„ã‚‹ã“ã¨
 }

--- a/cui/SlamLauncher.h
+++ b/cui/SlamLauncher.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -34,18 +34,18 @@
 class SlamLauncher
 {
 private:
-  int startN;                      // ŠJnƒXƒLƒƒƒ“”Ô†
-  int drawSkip;                    // •`‰æŠÔŠu
-  bool odometryOnly;               // ƒIƒhƒƒgƒŠ‚É‚æ‚é’n}\’z‚©
-  Pose2D ipose;                    // ƒIƒhƒƒgƒŠ’n}\’z‚Ì•â•ƒf[ƒ^B‰ŠúˆÊ’u‚ÌŠp“x‚ğ0‚É‚·‚é
+  int startN;                      // é–‹å§‹ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
+  int drawSkip;                    // æç”»é–“éš”
+  bool odometryOnly;               // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰ã‹
+  Pose2D ipose;                    // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªåœ°å›³æ§‹ç¯‰ã®è£œåŠ©ãƒ‡ãƒ¼ã‚¿ã€‚åˆæœŸä½ç½®ã®è§’åº¦ã‚’0ã«ã™ã‚‹
 
-  Pose2D lidarOffset;              // ƒŒ[ƒUƒXƒLƒƒƒi‚Æƒƒ{ƒbƒg‚Ì‘Š‘ÎˆÊ’u
+  Pose2D lidarOffset;              // ãƒ¬ãƒ¼ã‚¶ã‚¹ã‚­ãƒ£ãƒŠã¨ãƒ­ãƒœãƒƒãƒˆã®ç›¸å¯¾ä½ç½®
 
-  SensorDataReader sreader;        // ƒtƒ@ƒCƒ‹‚©‚ç‚ÌƒZƒ“ƒTƒf[ƒ^“Ç‚İ‚İ
-  PointCloudMap *pcmap;            // “_ŒQ’n}
-  SlamFrontEnd sfront;             // SLAMƒtƒƒ“ƒgƒGƒ“ƒh
-  MapDrawer mdrawer;               // gnuplot‚É‚æ‚é•`‰æ
-  FrameworkCustomizer fcustom;     // ƒtƒŒ[ƒ€ƒ[ƒN‚Ì‰ü‘¢
+  SensorDataReader sreader;        // ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã®ã‚»ãƒ³ã‚µãƒ‡ãƒ¼ã‚¿èª­ã¿è¾¼ã¿
+  PointCloudMap *pcmap;            // ç‚¹ç¾¤åœ°å›³
+  SlamFrontEnd sfront;             // SLAMãƒ•ãƒ­ãƒ³ãƒˆã‚¨ãƒ³ãƒ‰
+  MapDrawer mdrawer;               // gnuplotã«ã‚ˆã‚‹æç”»
+  FrameworkCustomizer fcustom;     // ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ã®æ”¹é€ 
 
 public:
   SlamLauncher() : startN(0), drawSkip(10), odometryOnly(false), pcmap(nullptr) {

--- a/cui/main.cpp
+++ b/cui/main.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -15,27 +15,27 @@
 #include "SlamLauncher.h"
 
 int main(int argc, char *argv[]) {
-  bool scanCheck=false;              // ƒXƒLƒƒƒ“•\¦‚Ì‚İ‚©
-  bool odometryOnly=false;           // ƒIƒhƒƒgƒŠ‚É‚æ‚é’n}\’z‚©
-  char *filename;                    // ƒf[ƒ^ƒtƒ@ƒCƒ‹–¼
-  int startN=0;                      // ŠJnƒXƒLƒƒƒ“”Ô†
+  bool scanCheck=false;              // ã‚¹ã‚­ãƒ£ãƒ³è¡¨ç¤ºã®ã¿ã‹
+  bool odometryOnly=false;           // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰ã‹
+  char *filename;                    // ãƒ‡ãƒ¼ã‚¿ãƒ•ã‚¡ã‚¤ãƒ«å
+  int startN=0;                      // é–‹å§‹ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
 
   if (argc < 2) {
     printf("Error: too few arguments.\n");
     return(1);
   }
 
-  // ƒRƒ}ƒ“ƒhˆø”‚Ìˆ—
+  // ã‚³ãƒãƒ³ãƒ‰å¼•æ•°ã®å‡¦ç†
   int idx=1;
-  // ƒRƒ}ƒ“ƒhƒIƒvƒVƒ‡ƒ“‚Ì‰ğßi'-'‚Ì‚Â‚¢‚½ˆø”j
+  // ã‚³ãƒãƒ³ãƒ‰ã‚ªãƒ—ã‚·ãƒ§ãƒ³ã®è§£é‡ˆï¼ˆ'-'ã®ã¤ã„ãŸå¼•æ•°ï¼‰
   if (argv[1][0] == '-') {
     for (int i=1; ; i++) {
       char option = argv[1][i];
       if (option == NULL)
         break;
-      else if (option == 's')        // ƒXƒLƒƒƒ“•\¦‚Ì‚İ
+      else if (option == 's')        // ã‚¹ã‚­ãƒ£ãƒ³è¡¨ç¤ºã®ã¿
         scanCheck = true;
-      else if (option == 'o')        // ƒIƒhƒƒgƒŠ‚É‚æ‚é’n}\’z
+      else if (option == 'o')        // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹åœ°å›³æ§‹ç¯‰
         odometryOnly = true;
     }
     if (argc == 2) {
@@ -44,9 +44,9 @@ int main(int argc, char *argv[]) {
     }
     ++idx;
   }
-  if (argc >= idx+1)                 // '-'‚ ‚éê‡idx=2A‚È‚¢ê‡idx=1
+  if (argc >= idx+1)                 // '-'ã‚ã‚‹å ´åˆidx=2ã€ãªã„å ´åˆidx=1
     filename = argv[idx];
-  if (argc == idx+2)                 // argc‚ªidx‚æ‚è2‘å‚«‚¯‚ê‚ÎstartN‚ª‚ ‚é
+  if (argc == idx+2)                 // argcãŒidxã‚ˆã‚Š2å¤§ãã‘ã‚Œã°startNãŒã‚ã‚‹
     startN = atoi(argv[idx+1]);
   else if (argc >= idx+2) {
     printf("Error: invalid arguments.\n");
@@ -56,18 +56,18 @@ int main(int argc, char *argv[]) {
   printf("SlamLauncher: startN=%d, scanCheck=%d, odometryOnly=%d\n", startN, scanCheck, odometryOnly);
   printf("filename=%s\n", filename);
 
-  // ƒtƒ@ƒCƒ‹‚ğŠJ‚­
+  // ãƒ•ã‚¡ã‚¤ãƒ«ã‚’é–‹ã
   SlamLauncher sl;
   bool flag = sl.setFilename(filename);
   if (!flag)
     return(1);
 
-  sl.setStartN(startN);              // ŠJnƒXƒLƒƒƒ“”Ô†‚Ìİ’è
+  sl.setStartN(startN);              // é–‹å§‹ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®è¨­å®š
 
-  // ˆ—–{‘Ì
+  // å‡¦ç†æœ¬ä½“
   if (scanCheck)
     sl.showScans();
-  else {                             // ƒXƒLƒƒƒ“•\¦ˆÈŠO‚ÍSlamLauncher“à‚Åê‡•ª‚¯
+  else {                             // ã‚¹ã‚­ãƒ£ãƒ³è¡¨ç¤ºä»¥å¤–ã¯SlamLauncherå†…ã§å ´åˆåˆ†ã‘
     sl.setOdometryOnly(odometryOnly);
     sl.customizeFramework();
     sl.run();

--- a/doc/customize.md
+++ b/doc/customize.md
@@ -1,46 +1,46 @@
-## �v���O�����̃J�X�^�}�C�Y
+﻿## プログラムのカスタマイズ
 
-LittleSLAM�́A�傫���A�X�L�����}�b�`���O�A�Z���T�Z���A���[�v�����݂Ƃ���
-�v�f�Z�p����\������Ă��܂��B
-LittleSLAM�́A�w�K�p�v���O�����Ƃ��āA�����̋Z�p�Ɋւ���
-�������̃J�X�^�}�C�Y���ł���悤�ɍ���Ă��܂��B
-���\�ɃJ�X�^�}�C�Y�̃^�C�v�������܂��B
-���ꂼ��̏ڍׂ́A�Q�l����[1]���Q�Ƃ��Ă��������B
+LittleSLAMは、大きく、スキャンマッチング、センサ融合、ループ閉じ込みという
+要素技術から構成されています。
+LittleSLAMは、学習用プログラムとして、これらの技術に関して
+いくつかのカスタマイズができるように作られています。
+下表にカスタマイズのタイプを示します。
+それぞれの詳細は、参考書籍[1]を参照してください。
 
 
-| �^�C�v              | ���e         |
+| タイプ              | 内容         |
 |:--------------------|:-------------|
-| customizeA          | �X�L�����}�b�`���O��{�`  |
-| customizeB          | �X�L�����}�b�`���O���ǌ`1 |
-| customizeC          | �X�L�����}�b�`���O���ǌ`2 |
-| customizeD          | �X�L�����}�b�`���O���ǌ`3 | 
-| customizeE          | �X�L�����}�b�`���O���ǌ`4 |
-| customizeF          | �X�L�����}�b�`���O���ǌ`5 | 
-| customizeG          | �X�L�����}�b�`���O���ǌ`6 | 
-| customizeH          | �Z���T�Z���ɂ��މ��̑Ώ� |
-| customizeI          | ���[�v������ |
+| customizeA          | スキャンマッチング基本形  |
+| customizeB          | スキャンマッチング改良形1 |
+| customizeC          | スキャンマッチング改良形2 |
+| customizeD          | スキャンマッチング改良形3 | 
+| customizeE          | スキャンマッチング改良形4 |
+| customizeF          | スキャンマッチング改良形5 | 
+| customizeG          | スキャンマッチング改良形6 | 
+| customizeH          | センサ融合による退化の対処 |
+| customizeI          | ループ閉じ込み |
 
 
-�J�X�^�}�C�Y�̃^�C�v�́ASlamLauncher.cpp��
-�֐�customizeFramework�̒��ŁA���L�̂悤�Ɏw�肵�܂��B
-�\�̃^�C�v�����̂܂܊֐����ł���A�w�肵�����֐��������āA
-����ȊO�̓R�����g�A�E�g���܂��B  
-�f�t�H���g�́AcustomizeI�ɂȂ��Ă��܂��B
+カスタマイズのタイプは、SlamLauncher.cppの
+関数customizeFrameworkの中で、下記のように指定します。
+表のタイプがそのまま関数名であり、指定したい関数を書いて、
+それ以外はコメントアウトします。  
+デフォルトは、customizeIになっています。
 
 ```C++
 
 void SlamLauncher::customizeFramework() {
   fcustom.setSlamFrontEnd(&sfront);
   fcustom.makeFramework();
-//  fcustom.customizeG();                   // �g��Ȃ��̂ŃR�����g�A�E�g
-  fcustom.customizeI();                     // ���̃J�X�^�}�C�Y���w��
+//  fcustom.customizeG();                   // 使わないのでコメントアウト
+  fcustom.customizeI();                     // このカスタマイズを指定
 
   pcmap = fcustom.getPointCloudMap();
 }
 
 ```  
 
-�܂��A�֐�customizeX�iX=A to I�j�́Acui/FrameworkCustomizer.cpp�Œ�`����Ă��܂��B  
-���[�U���V����customizeX������Ď������Ƃ��\�ł��B
+また、関数customizeX（X=A to I）は、cui/FrameworkCustomizer.cppで定義されています。  
+ユーザが新しいcustomizeXを作って試すことも可能です。
 
 

--- a/doc/install-linux.md
+++ b/doc/install-linux.md
@@ -1,45 +1,45 @@
-## LittleSLAM�̎g�����iLinux�̏ꍇ�j
+﻿## LittleSLAMの使い方（Linuxの場合）
 
-### (1) �֘A�\�t�g�E�F�A�̃C���X�g�[��
+### (1) 関連ソフトウェアのインストール
 
-- C++�R���p�C��(gcc)�ABoost�AEigen�ACMake, gnuplot  
-�ȉ��̃R�}���h�ŁA�܂Ƃ߂ăC���X�g�[�����܂��B
+- C++コンパイラ(gcc)、Boost、Eigen、CMake, gnuplot  
+以下のコマンドで、まとめてインストールします。
 
 </code></pre>
 <pre><code> $ sudo apt-get install build-essential cmake libboost-all-dev libeigen3-dev gnuplot gnuplot-x11
 </code></pre>
 
 - p2o  
-[p2o](https://github.com/furo-org/p2o)��Github�T�C�g���J���܂��B�ȉ��̂ǂ��炩�̕��@��p2o���_�E�����[�h���܂��B  
-(A) Github��ʂ�"Clone or download"�{�^���������āA"Download ZIP"��I�����A
-p2o-master.zip���_�E�����[�h���܂��Bzip�t�@�C���̓W�J���@�͌�q���܂��B  
-(B) git���g���āA���|�W�g����clone���܂��B  
+[p2o](https://github.com/furo-org/p2o)のGithubサイトを開きます。以下のどちらかの方法でp2oをダウンロードします。  
+(A) Github画面の"Clone or download"ボタンを押して、"Download ZIP"を選択し、
+p2o-master.zipをダウンロードします。zipファイルの展開方法は後述します。  
+(B) gitを使って、リポジトリをcloneします。  
 
-### (2) LittleSLAM�̃C���X�g�[��
+### (2) LittleSLAMのインストール
 
-- LittleSLAM�̓W�J  
-[LittleSLAM](https://github.com/furo-org/LittleSLAM)��Github�T�C�g���J���܂��B
-�ȉ��̂ǂ��炩�̕��@��LittleSLAM���_�E�����[�h���܂��B  
-(A) Github��ʂ�"Clone or download"�{�^���������āA"Download ZIP"��I�����A
-LittleSLAM-master.zip���_�E�����[�h���܂��B
-�����āA����zip�t�@�C����K���ȃf�B���N�g���ɓW�J���܂��B
-�����ł́A���Ƃ��΁A"\~/LittleSLAM"�ɓW�J����Ƃ��܂��B
-LittleSLAM-master.zip�̒���"LittleSLAM-master"�f�B���N�g���̉���
-4�̃f�B���N�g����3�̃t�@�C����"\~/LittleSLAM"�̉��ɃR�s�[���܂��B  
-(B) git���g���āA���|�W�g����clone���܂��B
+- LittleSLAMの展開  
+[LittleSLAM](https://github.com/furo-org/LittleSLAM)のGithubサイトを開きます。
+以下のどちらかの方法でLittleSLAMをダウンロードします。  
+(A) Github画面の"Clone or download"ボタンを押して、"Download ZIP"を選択し、
+LittleSLAM-master.zipをダウンロードします。
+そして、このzipファイルを適当なディレクトリに展開します。
+ここでは、たとえば、"\~/LittleSLAM"に展開するとします。
+LittleSLAM-master.zipの中の"LittleSLAM-master"ディレクトリの下の
+4個のディレクトリと3個のファイルを"\~/LittleSLAM"の下にコピーします。  
+(B) gitを使って、リポジトリをcloneします。
 
-- p2o�̓W�J  
-"\~/LittleSLAM"�̉���p2o�f�B���N�g�����쐬���܂��B  
-�O�q��p2o-master.zip�̒��̃t�@�C��"p2o.h"��"\~/LittleSLAM/p2o"�ɃR�s�[���܂��B  
+- p2oの展開  
+"\~/LittleSLAM"の下にp2oディレクトリを作成します。  
+前述のp2o-master.zipの中のファイル"p2o.h"を"\~/LittleSLAM/p2o"にコピーします。  
 
-- build�f�B���N�g���̍쐬  
-"\~/LittleSLAM"�̉���build�f�B���N�g�����쐬���܂��B  
-�����܂ł̃f�B���N�g���\���͈ȉ��̂悤�ɂȂ�܂��B
+- buildディレクトリの作成  
+"\~/LittleSLAM"の下にbuildディレクトリを作成します。  
+ここまでのディレクトリ構成は以下のようになります。
 
-![�f�B���N�g���\��](images/folders-lnx.png)
+![ディレクトリ構成](images/folders-lnx.png)
 
-- CMake�̎��s  
-�R���\�[���ŁAbuild�f�B���N�g���Ɉړ����Acmake�����s���܂��B
+- CMakeの実行  
+コンソールで、buildディレクトリに移動し、cmakeを実行します。
 
 </code></pre>
 <pre><code> ~/LittleSLAM$ cd build
@@ -47,50 +47,50 @@ LittleSLAM-master.zip�̒���"LittleSLAM-master"�f�B���N�g���̉���
 <pre><code> ~/LittleSLAM/build$ cmake ..
 </code></pre>
 
-���}��cmake�̎��s��������܂��B
+下図にcmakeの実行例を示します。
 
 ![cmake](images/cmake-lnx.png)
 
-���邢�́ACMake��GUI�ł��C���X�g�[�����āAWindows�̏ꍇ�Ɠ����悤��
-GUI��CMake�����s���邱�Ƃ��ł��܂��B
+あるいは、CMakeのGUI版をインストールして、Windowsの場合と同じように
+GUIでCMakeを実行することもできます。
 
-- �r���h  
-�R���\�[���ŁAbuild�f�B���N�g���ɂ�����make�����s���܂��B  
+- ビルド  
+コンソールで、buildディレクトリにおいてmakeを実行します。  
 </code></pre>
 <pre><code> ~/LittleSLAM/build$ make
 </code></pre>
-�r���h����������ƁA"\~/LittleSLAM/build/cui"�f�B���N�g���ɁA���s�t�@�C��LittleSLAM����������܂��B  
+ビルドが成功すると、"\~/LittleSLAM/build/cui"ディレクトリに、実行ファイルLittleSLAMが生成されます。  
 
 ![cmake](images/exefile-lnx.png)
 
-### (3) ���s
+### (3) 実行
 
-�ȉ��̃R�}���h�ŁALittleSLAM�����s���܂��B
+以下のコマンドで、LittleSLAMを実行します。
 
 </code></pre>
-<pre><code> ./LittleSLAM [-so] �f�[�^�t�@�C���� [�J�n�X�L�����ԍ�]
+<pre><code> ./LittleSLAM [-so] データファイル名 [開始スキャン番号]
 </code></pre>
 
--s�I�v�V�������w�肷��ƁA�X�L������1���`�悵�܂��B�e�X�L�����`����m�F�������ꍇ��
-�g���܂��B  
--o�I�v�V�������w�肷��ƁA�X�L�������I�h���g���f�[�^�ŕ��ׂ��n�}
-�iSLAM�ɂ��n�}�ł͂Ȃ��j�𐶐����܂��B  
-�I�v�V�����w�肪�Ȃ���΁ASLAM�����s���܂��B  
-�J�n�X�L�����ԍ����w�肷��ƁA���̔ԍ��܂ŃX�L������ǂݔ�΂��Ă�����s���܂��B
+-sオプションを指定すると、スキャンを1個ずつ描画します。各スキャン形状を確認したい場合に
+使います。  
+-oオプションを指定すると、スキャンをオドメトリデータで並べた地図
+（SLAMによる地図ではない）を生成します。  
+オプション指定がなければ、SLAMを実行します。  
+開始スキャン番号を指定すると、その番号までスキャンを読み飛ばしてから実行します。
 
-��Ƃ��āA�ȉ��̃R�}���h��SLAM�����s���܂��B  
-���̗�ł�"\~/LittleSLAM/dataset"�f�B���N�g����"corridor.lsc"�Ƃ����f�[�^�t�@�C�����u����Ă��܂��B  
+例として、以下のコマンドでSLAMを実行します。  
+この例では"\~/LittleSLAM/dataset"ディレクトリに"corridor.lsc"というデータファイルが置かれています。  
 </code></pre>
 <pre><code> ~/LittleSLAM/build/cui$ ./LittleSLAM ~/LittleSLAM/dataset/corridor.lsc
 </code></pre>
 
 ![cmake](images/command-lnx.png)  
   
-�R�}���h�����s����ƁALittleSLAM�̓t�@�C������f�[�^��ǂݍ���Œn�}����������
-�\�z���Ă����܂��B���̗l�q��gnuplot�ɕ`�悳��܂��B  
-�ŏI�I�ɁA���}�̂悤�Ȓn�}����������܂��B  
-�������I����Ă��A�v���O�����͏I�������A�n�}�͂��̂܂ܕ\������Ă��܂��B  
-�v���O�������I������ɂ�Ctrl-C�������Ă��������B
+コマンドを実行すると、LittleSLAMはファイルからデータを読み込んで地図を少しずつ
+構築していきます。その様子がgnuplotに描画されます。  
+最終的に、下図のような地図が生成されます。  
+処理が終わっても、プログラムは終了せず、地図はそのまま表示されています。  
+プログラムを終了するにはCtrl-Cを押してください。
 
-�@
+　
 ![cmake](images/result-lnx.png)

--- a/doc/install-win.md
+++ b/doc/install-win.md
@@ -1,129 +1,129 @@
-## LittleSLAM�̎g���� �iWindows�̏ꍇ�j
+﻿## LittleSLAMの使い方 （Windowsの場合）
 
-### (1) �֘A�\�t�g�E�F�A�̃C���X�g�[��
+### (1) 関連ソフトウェアのインストール
 
 - Boost  
-[Boost](http://www.boost.org/)���_�E�����[�h���āA�K���ȃt�H���_�ɉ𓀂��܂��B  
-LiitleSLAM�ł́ABoost�̃w�b�_�t�@�C���������g�p����̂ŁA�r���h�͕K�v����܂���B
+[Boost](http://www.boost.org/)をダウンロードして、適当なフォルダに解凍します。  
+LiitleSLAMでは、Boostのヘッダファイルだけを使用するので、ビルドは必要ありません。
 
 - Eigen3  
-[Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page)��
-�_�E�����[�h���āA�K���ȃt�H���_�ɉ𓀂��܂��B  
-Eigen�̓w�b�_�t�@�C�������Ŏg�p���郉�C�u�����Ȃ̂ŁA�r���h�͕K�v����܂���B
+[Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page)を
+ダウンロードして、適当なフォルダに解凍します。  
+Eigenはヘッダファイルだけで使用するライブラリなので、ビルドは必要ありません。
 
 - gnuplot  
-[gnuplot](http://www.gnuplot.info/)���_�E�����[�h���ăC���X�g�[�����܂��B 
-LittleSLAM����́AAPI�ł͂Ȃ��A���s�R�}���h�ŌĂяo���̂ŁA
-Windows�̊��ϐ�Path��gnuplot�̃p�X��ݒ肵�Ă����܂��B  
-���Ƃ��΁Agnuplot���t�H���_C:\gnuplot�ɃC���X�g�[�������ꍇ�A"Path=... ;C:\gnuplot\bin; ..."�Ƃ��܂��B  
-�i�C���X�g�[���������Őݒ肵�Ă���邱�Ƃ�����܂��j
+[gnuplot](http://www.gnuplot.info/)をダウンロードしてインストールします。 
+LittleSLAMからは、APIではなく、実行コマンドで呼び出すので、
+Windowsの環境変数Pathにgnuplotのパスを設定しておきます。  
+たとえば、gnuplotをフォルダC:\gnuplotにインストールした場合、"Path=... ;C:\gnuplot\bin; ..."とします。  
+（インストーラが自動で設定してくれることもあります）
 
 - CMake  
-[CMake](https://cmake.org/)���_�E�����[�h���ăC���X�g�[�����܂��B
+[CMake](https://cmake.org/)をダウンロードしてインストールします。
 
 - p2o  
-[p2o](https://github.com/furo-org/p2o)��Github�T�C�g���J���܂��B�ȉ��̂ǂ��炩�̕��@��p2o���_�E�����[�h���܂��B  
-(A) Github��ʂ�"Clone or download"�{�^���������āA"Download ZIP"��I�����A
-p2o-master.zip���_�E�����[�h���܂��Bzip�t�@�C���̓W�J���@�͌�q���܂��B  
-(B) git���g���āA���|�W�g����clone���܂��B  
+[p2o](https://github.com/furo-org/p2o)のGithubサイトを開きます。以下のどちらかの方法でp2oをダウンロードします。  
+(A) Github画面の"Clone or download"ボタンを押して、"Download ZIP"を選択し、
+p2o-master.zipをダウンロードします。zipファイルの展開方法は後述します。  
+(B) gitを使って、リポジトリをcloneします。  
 
-### (2) LittleSLAM�̃C���X�g�[��
+### (2) LittleSLAMのインストール
 
-- LittleSLAM�̓W�J  
-[LittleSLAM](https://github.com/furo-org/LittleSLAM)��Github�T�C�g���J���܂��B
-�ȉ��̂ǂ��炩�̕��@��LittleSLAM���_�E�����[�h���܂��B  
-(A) Github��ʂ�"Clone or download"�{�^���������āA"Download ZIP"��I�����A
-LittleSLAM-master.zip���_�E�����[�h���܂��B
-�����āA����zip�t�@�C����K���ȃt�H���_�ɓW�J���܂��B
-�����ł́A���Ƃ��΁A"C:\abc\LittleSLAM"�ɓW�J����Ƃ��܂��B
-"abc"�̓��[�U�����߂�C�ӂ̃t�H���_�ł��B
-LittleSLAM-master.zip�̒���"LittleSLAM-master"�t�H���_�̉���
-4�̃t�H���_��3�̃t�@�C����"C:\abc\LittleSLAM"�̉��ɃR�s�[���܂��B  
-(B) git���g���āA���|�W�g����clone���܂��B  
+- LittleSLAMの展開  
+[LittleSLAM](https://github.com/furo-org/LittleSLAM)のGithubサイトを開きます。
+以下のどちらかの方法でLittleSLAMをダウンロードします。  
+(A) Github画面の"Clone or download"ボタンを押して、"Download ZIP"を選択し、
+LittleSLAM-master.zipをダウンロードします。
+そして、このzipファイルを適当なフォルダに展開します。
+ここでは、たとえば、"C:\abc\LittleSLAM"に展開するとします。
+"abc"はユーザが決める任意のフォルダです。
+LittleSLAM-master.zipの中の"LittleSLAM-master"フォルダの下の
+4個のフォルダと3個のファイルを"C:\abc\LittleSLAM"の下にコピーします。  
+(B) gitを使って、リポジトリをcloneします。  
 
-- p2o�̓W�J   
-"C:\abc\LittleSLAM"�̉���"p2o"�t�H���_���쐬���܂��B  
-�O�q��p2o-master.zip�̒��̃t�@�C��"p2o.h"��"C:\abc\LittleSLAM\p2o"�̉��ɃR�s�[���܂��B  
+- p2oの展開   
+"C:\abc\LittleSLAM"の下に"p2o"フォルダを作成します。  
+前述のp2o-master.zipの中のファイル"p2o.h"を"C:\abc\LittleSLAM\p2o"の下にコピーします。  
 
-- build�t�H���_�̍쐬  
-"C:\abc\LittleSLAM"�̉���build�t�H���_���쐬���܂��B  
-�����܂ł̃t�H���_�\���͈ȉ��̂悤�ɂȂ�܂��B
+- buildフォルダの作成  
+"C:\abc\LittleSLAM"の下にbuildフォルダを作成します。  
+ここまでのフォルダ構成は以下のようになります。
 
-![�t�H���_�\��](images/folders.png)
+![フォルダ構成](images/folders.png)
 
-- CMake�̎��s  
-CMake(GUI)�����s���āALittleSLAM.sln�𐶐����܂��B  
-�܂��A"Where is the source code"�������"Where to buid the binaries"���ɉ��}�̃t�H���_���w�肵�܂��B  
-���ɁA Configure�{�^���������܂��B  
-LittleSLAM�ɑ΂��ď��߂�CMake�����s����ꍇ�A���}�̂悤��C++�R���p�C���𕷂����̂ŁA
-�g�p���Ă���C++�R���p�C�����w�肵�A"Use default native compliers"��I�����āAFinish�{�^���������܂��B  
-�����āA������x�AConfigure�{�^���������A�Ō��Generate�{�^���������܂��B
+- CMakeの実行  
+CMake(GUI)を実行して、LittleSLAM.slnを生成します。  
+まず、"Where is the source code"欄および"Where to buid the binaries"欄に下図のフォルダを指定します。  
+次に、 Configureボタンを押します。  
+LittleSLAMに対して初めてCMakeを実行する場合、下図のようにC++コンパイラを聞かれるので、
+使用しているC++コンパイラを指定し、"Use default native compliers"を選択して、Finishボタンを押します。  
+そして、もう一度、Configureボタンを押し、最後にGenerateボタンを押します。
 
 
 ![cmake](images/cmake.png)
 
-- Eigen3�̎w��   
-�����ACMake��Eigen3�̏ꏊ�iEIGEN3_INCLUDE_DIR�j��������ꂸ�ɃG���[���o���ꍇ�́A
-���̂����ꂩ���s���āACMake���ċN������Configure��Generate����蒼���Ă��������B  
-(A) Windows�̃V�X�e�����ϐ���EIGEN3_ROOT_DIR��ǉ����āA
-������Eigen3��W�J�����t�H���_��ݒ肵�܂��B  
-����ƁA���}�̂悤�ɁA"C:\abc\LittleSLAM"����cui, framework, hook�̊eCMakeLists.txt�̒��ŁA
-EIGEN3_ROOT_DIR�Ŏw�肳�ꂽ�t�H���_��EIGEN3_INCLUDE_DIR�ɐݒ肳��܂��B  
-(B) �eCMakeLists.txt��Eigen3�̃t�H���_����Őݒ肵�܂��B
-���Ƃ��΁AEigen3��"C:\eigen"�ɓW�J�����ꍇ�́A���}��
-$ENV{EIGEN3_ROOT_DIR}�̕�����C:\eigen�ɏ��������܂��B  
+- Eigen3の指定   
+もし、CMakeがEigen3の場所（EIGEN3_INCLUDE_DIR）を見つけられずにエラーが出た場合は、
+次のいずれかを行って、CMakeを再起動してConfigureとGenerateをやり直してください。  
+(A) Windowsのシステム環境変数にEIGEN3_ROOT_DIRを追加して、
+そこにEigen3を展開したフォルダを設定します。  
+すると、下図のように、"C:\abc\LittleSLAM"下のcui, framework, hookの各CMakeLists.txtの中で、
+EIGEN3_ROOT_DIRで指定されたフォルダがEIGEN3_INCLUDE_DIRに設定されます。  
+(B) 各CMakeLists.txtのEigen3のフォルダを手で設定します。
+たとえば、Eigen3を"C:\eigen"に展開した場合は、下図の
+$ENV{EIGEN3_ROOT_DIR}の部分をC:\eigenに書き換えます。  
 
 ```
--- CMakeLists.txt��蔲�� --
+-- CMakeLists.txtより抜粋 --
 
 find_package(Eigen3)  
-IF(NOT EIGEN3_INCLUDE_DIR)          # Eigen3�̃p�X��������Ȃ�
+IF(NOT EIGEN3_INCLUDE_DIR)          # Eigen3のパスが見つからない
   set(EIGEN3_INCLUDE_DIR $ENV{EIGEN3_ROOT_DIR})
 ENDIF() 
 ```  
 
-- Visual studio�̋N��  
-"C:\abc\LittleSLAM\build"�̉���LittleSLAM.sln���ł��Ă���̂ŁA
-������_�u���N���b�N����ƁAVisual studio���N�����܂��B
+- Visual studioの起動  
+"C:\abc\LittleSLAM\build"の下にLittleSLAM.slnができているので、
+それをダブルクリックすると、Visual studioが起動します。
 
-- �r���h  
-���}�̂悤�ɁAVisual studio�ŁARelease, x64�i64�r�b�g�̏ꍇ�j���w�肵�ABuild���j���[����Build Solution�����s���܂��B
+- ビルド  
+下図のように、Visual studioで、Release, x64（64ビットの場合）を指定し、BuildメニューからBuild Solutionを実行します。
 
 ![cmake](images/build.png)
 
 
-�r���h����������ƁA"build\cui\Release"�t�H���_�ɁA���s�t�@�C��LittleSLAM.exe����������܂��B  
+ビルドが成功すると、"build\cui\Release"フォルダに、実行ファイルLittleSLAM.exeが生成されます。  
 
 ![cmake](images/exefile.png)
 
-### (3) ���s
+### (3) 実行
 
-Windows�R�}���h�v�����v�g����ȉ��̃R�}���h�ɂ��ALittleSLAM�����s���܂��B
+Windowsコマンドプロンプトから以下のコマンドにより、LittleSLAMを実行します。
 
 </code></pre>
-<pre><code> LittleSLAM [-so] �f�[�^�t�@�C���� [�J�n�X�L�����ԍ�]
+<pre><code> LittleSLAM [-so] データファイル名 [開始スキャン番号]
 </code></pre>
 
--s�I�v�V�������w�肷��ƁA�X�L������1���`�悵�܂��B�e�X�L�����`����m�F�������ꍇ��
-�g���܂��B  
--o�I�v�V�������w�肷��ƁA�X�L�������I�h���g���f�[�^�ŕ��ׂ��n�}
-�iSLAM�ɂ��n�}�ł͂Ȃ��j�𐶐����܂��B  
-�I�v�V�����w�肪�Ȃ���΁ASLAM�����s���܂��B  
-�J�n�X�L�����ԍ����w�肷��ƁA���̔ԍ��܂ŃX�L������ǂݔ�΂��Ă�����s���܂��B
+-sオプションを指定すると、スキャンを1個ずつ描画します。各スキャン形状を確認したい場合に
+使います。  
+-oオプションを指定すると、スキャンをオドメトリデータで並べた地図
+（SLAMによる地図ではない）を生成します。  
+オプション指定がなければ、SLAMを実行します。  
+開始スキャン番号を指定すると、その番号までスキャンを読み飛ばしてから実行します。
 
-��Ƃ��āA�ȉ��̃R�}���h��SLAM�����s���܂��B  
-���̗�ł�"C:\abc\dataset"�t�H���_��"corridor.lsc"�Ƃ����f�[�^�t�@�C�����u����Ă��܂��B  
+例として、以下のコマンドでSLAMを実行します。  
+この例では"C:\abc\dataset"フォルダに"corridor.lsc"というデータファイルが置かれています。  
 </code></pre>
 <pre><code> C:\abc\LittleSLAM\build\cui\Release> LittleSLAM C:\abc\dataset\corridor.lsc
 </code></pre>
 
 ![cmake](images/command.png)  
   
-�R�}���h�����s����ƁALittleSLAM�̓t�@�C������f�[�^��ǂݍ���Œn�}����������
-�\�z���Ă����܂��B���̗l�q��gnuplot�ɕ`�悳��܂��B  
-�ŏI�I�ɁA���}�̂悤�Ȓn�}����������܂��B  
-�������I����Ă��A�v���O�����͏I�������A�n�}�͂��̂܂ܕ\������Ă��܂��B  
-�v���O�������I������ɂ�Ctrl-C�������Ă��������B
+コマンドを実行すると、LittleSLAMはファイルからデータを読み込んで地図を少しずつ
+構築していきます。その様子がgnuplotに描画されます。  
+最終的に、下図のような地図が生成されます。  
+処理が終わっても、プログラムは終了せず、地図はそのまま表示されています。  
+プログラムを終了するにはCtrl-Cを押してください。
 
 
 ![cmake](images/result.png)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT(framework)
+﻿PROJECT(framework)
 
 cmake_minimum_required(VERSION 2.8)
 

--- a/framework/CostFunction.h
+++ b/framework/CostFunction.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,10 +24,10 @@
 class CostFunction
 {
 protected:
-  std::vector<const LPoint2D*> curLps;         // ‘Î‰‚ª‚Æ‚ê‚½Œ»İƒXƒLƒƒƒ“‚Ì“_ŒQ
-  std::vector<const LPoint2D*> refLps;         // ‘Î‰‚ª‚Æ‚ê‚½QÆƒXƒLƒƒƒ“‚Ì“_ŒQ
-  double evlimit;                              // ƒ}ƒbƒ`ƒ“ƒO‚Å‘Î‰‚ª‚Æ‚ê‚½‚ÆŒ©‚È‚·‹——£è‡’l
-  double pnrate;                               // Œë·‚ªevlimitˆÈ“à‚Å‘Î‰‚ª‚Æ‚ê‚½“_‚Ì”ä—¦
+  std::vector<const LPoint2D*> curLps;         // å¯¾å¿œãŒã¨ã‚ŒãŸç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤
+  std::vector<const LPoint2D*> refLps;         // å¯¾å¿œãŒã¨ã‚ŒãŸå‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤
+  double evlimit;                              // ãƒãƒƒãƒãƒ³ã‚°ã§å¯¾å¿œãŒã¨ã‚ŒãŸã¨è¦‹ãªã™è·é›¢é–¾å€¤
+  double pnrate;                               // èª¤å·®ãŒevlimitä»¥å†…ã§å¯¾å¿œãŒã¨ã‚ŒãŸç‚¹ã®æ¯”ç‡
 
 public:
   CostFunction() : evlimit(0), pnrate(0) {
@@ -42,7 +42,7 @@ public:
     evlimit = e;
   }
 
-  // DataAssociator‚Å‘Î‰‚Ì‚Æ‚ê‚½“_ŒQcur, ref‚ğİ’è
+  // DataAssociatorã§å¯¾å¿œã®ã¨ã‚ŒãŸç‚¹ç¾¤cur, refã‚’è¨­å®š
   void setPoints(std::vector<const LPoint2D*> &cur, std::vector<const LPoint2D*> &ref) {
     curLps = cur;
     refLps = ref;

--- a/framework/CovarianceCalculator.cpp
+++ b/framework/CovarianceCalculator.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,38 +16,38 @@
 
 using namespace std;
 
-////////// ICP‚É‚æ‚é„’è’l‚Ì‹¤•ªU /////////
+////////// ICPã«ã‚ˆã‚‹æ¨å®šå€¤ã®å…±åˆ†æ•£ /////////
 
-// ICP‚É‚æ‚éƒƒ{ƒbƒgˆÊ’u‚Ì„’è’l‚Ì‹¤•ªUcov‚ğ‹‚ß‚éB
-// „’èˆÊ’uposeAŒ»İƒXƒLƒƒƒ““_ŒQcurLpsAQÆƒXƒLƒƒƒ““_ŒQrefLps
+// ICPã«ã‚ˆã‚‹ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®æ¨å®šå€¤ã®å…±åˆ†æ•£covã‚’æ±‚ã‚ã‚‹ã€‚
+// æ¨å®šä½ç½®poseã€ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤curLpsã€å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤refLps
 double CovarianceCalculator::calIcpCovariance(const Pose2D &pose, std::vector<const LPoint2D*> &curLps, std::vector<const LPoint2D*> &refLps, Eigen::Matrix3d &cov) {
   double tx = pose.tx;
   double ty = pose.ty;
   double th = pose.th;
   double a = DEG2RAD(th);
-  vector<double> Jx;                                         // ƒ„ƒRƒrs—ñ‚Ìx‚Ì—ñ
-  vector<double> Jy;                                         // ƒ„ƒRƒrs—ñ‚Ìy‚Ì—ñ
-  vector<double> Jt;                                         // ƒ„ƒRƒrs—ñ‚Ìth‚Ì—ñ
+  vector<double> Jx;                                         // ãƒ¤ã‚³ãƒ“è¡Œåˆ—ã®xã®åˆ—
+  vector<double> Jy;                                         // ãƒ¤ã‚³ãƒ“è¡Œåˆ—ã®yã®åˆ—
+  vector<double> Jt;                                         // ãƒ¤ã‚³ãƒ“è¡Œåˆ—ã®thã®åˆ—
 
   for (size_t i=0; i<curLps.size(); i++) {
-    const LPoint2D *clp = curLps[i];                         // Œ»İƒXƒLƒƒƒ“‚Ì“_
-    const LPoint2D *rlp = refLps[i];                         // QÆƒXƒLƒƒƒ“‚Ì“_
+    const LPoint2D *clp = curLps[i];                         // ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
+    const LPoint2D *rlp = refLps[i];                         // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
 
-    if (rlp->type == ISOLATE)                                // ŒÇ—§“_‚ÍœŠO
+    if (rlp->type == ISOLATE)                                // å­¤ç«‹ç‚¹ã¯é™¤å¤–
       continue;
 
-    double pd0 = calPDistance(clp, rlp, tx, ty, a);         // ƒRƒXƒgŠÖ”’l
-    double pdx = calPDistance(clp, rlp, tx+dd, ty, a);      // x‚ğ­‚µ•Ï‚¦‚½ƒRƒXƒgŠÖ”’l
-    double pdy = calPDistance(clp, rlp, tx, ty+dd, a);      // y‚ğ­‚µ•Ï‚¦‚½ƒRƒXƒgŠÖ”’l
-    double pdt = calPDistance(clp, rlp, tx, ty, a+da);      // th‚ğ­‚µ•Ï‚¦‚½ƒRƒXƒgŠÖ”’l
+    double pd0 = calPDistance(clp, rlp, tx, ty, a);         // ã‚³ã‚¹ãƒˆé–¢æ•°å€¤
+    double pdx = calPDistance(clp, rlp, tx+dd, ty, a);      // xã‚’å°‘ã—å¤‰ãˆãŸã‚³ã‚¹ãƒˆé–¢æ•°å€¤
+    double pdy = calPDistance(clp, rlp, tx, ty+dd, a);      // yã‚’å°‘ã—å¤‰ãˆãŸã‚³ã‚¹ãƒˆé–¢æ•°å€¤
+    double pdt = calPDistance(clp, rlp, tx, ty, a+da);      // thã‚’å°‘ã—å¤‰ãˆãŸã‚³ã‚¹ãƒˆé–¢æ•°å€¤
 
-    Jx.push_back((pdx - pd0)/dd);                            // •Î”÷•ªix¬•ªj
-    Jy.push_back((pdy - pd0)/dd);                            // •Î”÷•ªiy¬•ªj
-    Jt.push_back((pdt - pd0)/da);                            // •Î”÷•ªith¬•ªj
+    Jx.push_back((pdx - pd0)/dd);                            // åå¾®åˆ†ï¼ˆxæˆåˆ†ï¼‰
+    Jy.push_back((pdy - pd0)/dd);                            // åå¾®åˆ†ï¼ˆyæˆåˆ†ï¼‰
+    Jt.push_back((pdt - pd0)/da);                            // åå¾®åˆ†ï¼ˆthæˆåˆ†ï¼‰
   }
 
-  // ƒwƒbƒZs—ñ‚Ì‹ß—J^TJ‚ÌŒvZ
-  Eigen::Matrix3d hes = Eigen::Matrix3d::Zero(3,3);          // ‹ß—ƒwƒbƒZs—ñB0‚Å‰Šú‰»
+  // ãƒ˜ãƒƒã‚»è¡Œåˆ—ã®è¿‘ä¼¼J^TJã®è¨ˆç®—
+  Eigen::Matrix3d hes = Eigen::Matrix3d::Zero(3,3);          // è¿‘ä¼¼ãƒ˜ãƒƒã‚»è¡Œåˆ—ã€‚0ã§åˆæœŸåŒ–
   for (size_t i=0; i<Jx.size(); i++) {
     hes(0,0) += Jx[i]*Jx[i];
     hes(0,1) += Jx[i]*Jy[i];
@@ -56,43 +56,43 @@ double CovarianceCalculator::calIcpCovariance(const Pose2D &pose, std::vector<co
     hes(1,2) += Jy[i]*Jt[i];
     hes(2,2) += Jt[i]*Jt[i];
   }
-  // J^TJ‚ª‘ÎÌs—ñ‚Å‚ ‚é‚±‚Æ‚ğ—˜—p
+  // J^TJãŒå¯¾ç§°è¡Œåˆ—ã§ã‚ã‚‹ã“ã¨ã‚’åˆ©ç”¨
   hes(1,0) = hes(0,1);
   hes(2,0) = hes(0,2);
   hes(2,1) = hes(1,2);
 
-  // ‹¤•ªUs—ñ‚Íi‹ß—jƒwƒbƒZs—ñ‚Ì‹ts—ñ
+  // å…±åˆ†æ•£è¡Œåˆ—ã¯ï¼ˆè¿‘ä¼¼ï¼‰ãƒ˜ãƒƒã‚»è¡Œåˆ—ã®é€†è¡Œåˆ—
 //  cov = hes.inverse();
-  cov = MyUtil::svdInverse(hes);                              // SVD‚ğg‚¤•û‚ª­‚µ‚æ‚¢
+  cov = MyUtil::svdInverse(hes);                              // SVDã‚’ä½¿ã†æ–¹ãŒå°‘ã—ã‚ˆã„
 
   double vals[2], vec1[2], vec2[2];
-  double ratio = calEigen(cov, vals, vec1, vec2);            // ŒÅ—L’lŒvZ‚µ‚ÄA‘Ş‰»‹ï‡‚ğ’²‚×‚é
+  double ratio = calEigen(cov, vals, vec1, vec2);            // å›ºæœ‰å€¤è¨ˆç®—ã—ã¦ã€é€€åŒ–å…·åˆã‚’èª¿ã¹ã‚‹
 
-  // •K—v‚É‰‚¶‚Ä‹¤•ªUs—ñ‚ÌƒXƒP[ƒ‹‚ğ’²®‚·‚é
-//  double kk = 1;          // ‘Ş‰»‚Å‹É’[‚É‚¸‚ê‚éê‡
-  double kk = 0.1;       // ’Êí
+  // å¿…è¦ã«å¿œã˜ã¦å…±åˆ†æ•£è¡Œåˆ—ã®ã‚¹ã‚±ãƒ¼ãƒ«ã‚’èª¿æ•´ã™ã‚‹
+//  double kk = 1;          // é€€åŒ–ã§æ¥µç«¯ã«ãšã‚Œã‚‹å ´åˆ
+  double kk = 0.1;       // é€šå¸¸
   cov *= kk;
 
   return(ratio);
 }
 
-// ‚’¼‹——£‚ğ—p‚¢‚½ŠÏ‘ªƒ‚ƒfƒ‹‚Ì®
+// å‚ç›´è·é›¢ã‚’ç”¨ã„ãŸè¦³æ¸¬ãƒ¢ãƒ‡ãƒ«ã®å¼
 double CovarianceCalculator::calPDistance(const LPoint2D *clp, const LPoint2D *rlp, double tx, double ty, double th) {
-  double x = cos(th)*clp->x - sin(th)*clp->y + tx;                     // clp‚ğ„’èˆÊ’u‚ÅÀ•W•ÏŠ·
+  double x = cos(th)*clp->x - sin(th)*clp->y + tx;                     // clpã‚’æ¨å®šä½ç½®ã§åº§æ¨™å¤‰æ›
   double y = sin(th)*clp->x + cos(th)*clp->y + ty;
-  double pdis = (x - rlp->x)*rlp->nx + (y - rlp->y)*rlp->ny;           // À•W•ÏŠ·‚µ‚½“_‚©‚çrlp‚Ö‚Ì‚’¼‹——£
+  double pdis = (x - rlp->x)*rlp->nx + (y - rlp->y)*rlp->ny;           // åº§æ¨™å¤‰æ›ã—ãŸç‚¹ã‹ã‚‰rlpã¸ã®å‚ç›´è·é›¢
 
   return(pdis);
 }
 
-///////// ‰^“®ƒ‚ƒfƒ‹‚ÌŒvZ /////////
+///////// é‹å‹•ãƒ¢ãƒ‡ãƒ«ã®è¨ˆç®— /////////
 
 void CovarianceCalculator::calMotionCovarianceSimple(const Pose2D &motion, double dT, Eigen::Matrix3d &cov) {
-  double dis = sqrt(motion.tx*motion.tx + motion.ty*motion.ty);   // ˆÚ“®‹——£
-  double vt = dis/dT;                    // •Ài‘¬“x[m/s]
-  double wt = DEG2RAD(motion.th)/dT;     // Šp‘¬“x[rad/s]
-  double vthre = 0.02;                   // vt‚Ì‰ºŒÀ’lB“¯Šú‚¸‚ê‚Å0‚É‚È‚éê‡‚Ì‘Îˆ
-  double wthre = 0.05;                   // wt‚Ì‰ºŒÀ’l
+  double dis = sqrt(motion.tx*motion.tx + motion.ty*motion.ty);   // ç§»å‹•è·é›¢
+  double vt = dis/dT;                    // ä¸¦é€²é€Ÿåº¦[m/s]
+  double wt = DEG2RAD(motion.th)/dT;     // è§’é€Ÿåº¦[rad/s]
+  double vthre = 0.02;                   // vtã®ä¸‹é™å€¤ã€‚åŒæœŸãšã‚Œã§0ã«ãªã‚‹å ´åˆã®å¯¾å‡¦
+  double wthre = 0.05;                   // wtã®ä¸‹é™å€¤
 
   if (vt < vthre)
     vt = vthre;
@@ -104,18 +104,18 @@ void CovarianceCalculator::calMotionCovarianceSimple(const Pose2D &motion, doubl
   double da = wt;
 
   Eigen::Matrix3d C1;
-  C1.setZero();                          // ‘ÎŠp—v‘f‚¾‚¯“ü‚ê‚é
-  C1(0,0) = 0.001*dx*dx;                 // •Ài¬•ªx
-  C1(1,1) = 0.005*dy*dy;                 // •Ài¬•ªy
-//  C1(2,2) = 0.005*da*da;                 // ‰ñ“]¬•ª
-  C1(2,2) = 0.05*da*da;                 // ‰ñ“]¬•ª
+  C1.setZero();                          // å¯¾è§’è¦ç´ ã ã‘å…¥ã‚Œã‚‹
+  C1(0,0) = 0.001*dx*dx;                 // ä¸¦é€²æˆåˆ†x
+  C1(1,1) = 0.005*dy*dy;                 // ä¸¦é€²æˆåˆ†y
+//  C1(2,2) = 0.005*da*da;                 // å›è»¢æˆåˆ†
+  C1(2,2) = 0.05*da*da;                 // å›è»¢æˆåˆ†
 
-  // ƒXƒP[ƒ‹’²®
-//  double kk = 100;                     // ƒIƒhƒƒgƒŠ‚Ì‚¸‚ê‚ª‘å‚«‚¢ê‡
-  double kk = 1;                         // ’Êí
+  // ã‚¹ã‚±ãƒ¼ãƒ«èª¿æ•´
+//  double kk = 100;                     // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®ãšã‚ŒãŒå¤§ãã„å ´åˆ
+  double kk = 1;                         // é€šå¸¸
   cov = kk*C1;
 
-  // Šm”F—p
+  // ç¢ºèªç”¨
   printf("calMotionCovarianceSimple\n");
   printf("vt=%g, wt=%g\n", vt, wt);
   double vals[2], vec1[2], vec2[2];
@@ -123,22 +123,22 @@ void CovarianceCalculator::calMotionCovarianceSimple(const Pose2D &motion, doubl
   printf("cov : %g %g %g %g %g %g\n", cov(0,0), cov(0,1), cov(0,2), cov(1,1), cov(1,2), cov(2,2));
 }
 
-///////// ‰^“®ƒ‚ƒfƒ‹‚ÌŒvZ /////////
+///////// é‹å‹•ãƒ¢ãƒ‡ãƒ«ã®è¨ˆç®— /////////
 
-// 1ƒtƒŒ[ƒ€•ª‚Ì‘–s‚É‚æ‚éŒë·BdT‚Í1ƒtƒŒ[ƒ€‚ÌŠÔBmotion‚Í‚»‚ÌŠÔ‚ÌˆÚ“®—ÊB
+// 1ãƒ•ãƒ¬ãƒ¼ãƒ åˆ†ã®èµ°è¡Œã«ã‚ˆã‚‹èª¤å·®ã€‚dTã¯1ãƒ•ãƒ¬ãƒ¼ãƒ ã®æ™‚é–“ã€‚motionã¯ãã®é–“ã®ç§»å‹•é‡ã€‚
 void CovarianceCalculator::calMotionCovariance(double th, double dx, double dy, double dth, double dt, Eigen::Matrix3d &cov, bool accum) {
   setAlpha(1, 5);
-  double dis = sqrt(dx*dx + dy*dy);   // ‘–s‹——£
-  double vt = dis/dt;                 // •Ài‘¬“x[m/s]
-  double wt = dth/dt;                 // Šp‘¬“x[rad/s]
-  double vthre = 0.001;               // vt‚Ì‰ºŒÀ’lBƒ^ƒCƒ~ƒ“ƒO‚É‚æ‚è0‚É‚È‚é‚Ì‚ğ–h‚®B
-  double wthre = 0.01;                // wt‚Ì‰ºŒÀ’l
+  double dis = sqrt(dx*dx + dy*dy);   // èµ°è¡Œè·é›¢
+  double vt = dis/dt;                 // ä¸¦é€²é€Ÿåº¦[m/s]
+  double wt = dth/dt;                 // è§’é€Ÿåº¦[rad/s]
+  double vthre = 0.001;               // vtã®ä¸‹é™å€¤ã€‚ã‚¿ã‚¤ãƒŸãƒ³ã‚°ã«ã‚ˆã‚Š0ã«ãªã‚‹ã®ã‚’é˜²ãã€‚
+  double wthre = 0.01;                // wtã®ä¸‹é™å€¤
   if (vt < vthre)
     vt = vthre;
   if (wt < wthre)
     wt = wthre;
 
- // —İÏ‚·‚éê‡‚ÍAt-1‚Ì‹¤•ªUs—ñsigma‚©‚çAt‚Ì‹¤•ªUs—ñ‚ğŒvZ
+ // ç´¯ç©ã™ã‚‹å ´åˆã¯ã€æ™‚åˆ»t-1ã®å…±åˆ†æ•£è¡Œåˆ—sigmaã‹ã‚‰ã€æ™‚åˆ»tã®å…±åˆ†æ•£è¡Œåˆ—ã‚’è¨ˆç®—
   Eigen::Matrix3d A = Eigen::Matrix3d::Zero(3,3);
   if (accum) {
     Eigen::Matrix3d Jxk;
@@ -164,7 +164,7 @@ void CovarianceCalculator::calUk(double vt, double wt, Eigen::Matrix2d &Uk) {
         0, a2*wt*wt;
 }
 
-// ƒƒ{ƒbƒgp¨‚ÉŠÖ‚·‚éƒ„ƒRƒrs—ñBvt‚Íƒƒ{ƒbƒg‚Ì‘¬“xAth‚Íƒƒ{ƒbƒg‚Ì•ûŒü(ƒ‰ƒWƒAƒ“)Adt‚ÍŠÔ
+// ãƒ­ãƒœãƒƒãƒˆå§¿å‹¢ã«é–¢ã™ã‚‹ãƒ¤ã‚³ãƒ“è¡Œåˆ—ã€‚vtã¯ãƒ­ãƒœãƒƒãƒˆã®é€Ÿåº¦ã€thã¯ãƒ­ãƒœãƒƒãƒˆã®æ–¹å‘(ãƒ©ã‚¸ã‚¢ãƒ³)ã€dtã¯æ™‚é–“
 void CovarianceCalculator::calJxk(double th, double vt, double dt, Eigen::Matrix3d &Jxk) {
   double cs = cos(th);
   double sn = sin(th);
@@ -184,18 +184,18 @@ void CovarianceCalculator::calJuk(double th, double dt, Eigen::Matrix<double, 3,
 
 ////////////////
 
-// ‹¤•ªUs—ñcov‚Ì•Ài¬•ª‚¾‚¯‚ğŒÅ—L’l•ª‰ğ‚µAŒÅ—L’l‚ğvals‚ÉAŒÅ—LƒxƒNƒgƒ‹‚ğvec1‚Ævec2‚É“ü‚ê‚éB
+// å…±åˆ†æ•£è¡Œåˆ—covã®ä¸¦é€²æˆåˆ†ã ã‘ã‚’å›ºæœ‰å€¤åˆ†è§£ã—ã€å›ºæœ‰å€¤ã‚’valsã«ã€å›ºæœ‰ãƒ™ã‚¯ãƒˆãƒ«ã‚’vec1ã¨vec2ã«å…¥ã‚Œã‚‹ã€‚
 double CovarianceCalculator::calEigen(const Eigen::Matrix3d &cov, double *vals, double *vec1, double *vec2) {
-  // •Ài•”•ª‚¾‚¯æ‚èo‚·
+  // ä¸¦é€²éƒ¨åˆ†ã ã‘å–ã‚Šå‡ºã™
   double cv2[2][2];
   for (int i=0; i<2; i++) 
     for (int j=0; j<2; j++) 
       cv2[i][j] = cov(i,j);
 
-  MyUtil::calEigen2D(cv2, vals, vec1, vec2);        // ŒÅ—L’l•ª‰ğ
+  MyUtil::calEigen2D(cv2, vals, vec1, vec2);        // å›ºæœ‰å€¤åˆ†è§£
   double ratio = vals[0]/vals[1];
 
-  // Šm”F—p
+  // ç¢ºèªç”¨
   printf("Eigen: ratio=%g, val1=%g, val2=%g\n", ratio, vals[0], vals[1]);
   printf("Eigen: vec1=(%g, %g), ang=%g\n", vec1[0], vec1[1], RAD2DEG(atan2(vec1[1], vec1[0])));
 
@@ -204,7 +204,7 @@ double CovarianceCalculator::calEigen(const Eigen::Matrix3d &cov, double *vals, 
 
 //////////////
 
-// ‹¤•ªUs—ñ‚Ì—İÏB‘O‰ñˆÊ’u‚Ì‹¤•ªUs—ñprevCov‚ÉˆÚ“®—Ê‚Ì‹¤•ªUs—ñmcov‚ğ‰Á‚¦‚ÄAŒ»İˆÊ’u‚Ì‹¤•ªUs—ñcurCov‚ğ‹‚ß‚éB
+// å…±åˆ†æ•£è¡Œåˆ—ã®ç´¯ç©ã€‚å‰å›ä½ç½®ã®å…±åˆ†æ•£è¡Œåˆ—prevCovã«ç§»å‹•é‡ã®å…±åˆ†æ•£è¡Œåˆ—mcovã‚’åŠ ãˆã¦ã€ç¾åœ¨ä½ç½®ã®å…±åˆ†æ•£è¡Œåˆ—curCovã‚’æ±‚ã‚ã‚‹ã€‚
 void CovarianceCalculator::accumulateCovariance(const Pose2D &curPose, const Pose2D &prevPose, const Eigen::Matrix3d &prevCov, const Eigen::Matrix3d &mcov, Eigen::Matrix3d &curCov) {
   Eigen::Matrix3d J1, J2;
   J1 << 1, 0, -(curPose.ty - prevPose.ty),
@@ -222,11 +222,11 @@ void CovarianceCalculator::accumulateCovariance(const Pose2D &curPose, const Pos
 
 /////////////
 
-// ‹¤•ªUs—ñcov‚ğpose‚ÌŠp“x•ª‚¾‚¯‰ñ“]‚³‚¹‚é
+// å…±åˆ†æ•£è¡Œåˆ—covã‚’poseã®è§’åº¦åˆ†ã ã‘å›è»¢ã•ã›ã‚‹
 void CovarianceCalculator::rotateCovariance(const Pose2D &pose, const Eigen::Matrix3d &cov, Eigen::Matrix3d &icov, bool reverse) {
-  double cs = cos(DEG2RAD(pose.th));            // pose‚Ì‰ñ“]¬•ªth‚É‚æ‚écos
+  double cs = cos(DEG2RAD(pose.th));            // poseã®å›è»¢æˆåˆ†thã«ã‚ˆã‚‹cos
   double sn = sin(DEG2RAD(pose.th));
-  Eigen::Matrix3d J;                            // ‰ñ“]‚Ìƒ„ƒRƒrs—ñ
+  Eigen::Matrix3d J;                            // å›è»¢ã®ãƒ¤ã‚³ãƒ“è¡Œåˆ—
   J << cs, -sn, 0,
        sn, cs, 0,
        0, 0, 1;
@@ -234,7 +234,7 @@ void CovarianceCalculator::rotateCovariance(const Pose2D &pose, const Eigen::Mat
   Eigen::Matrix3d JT = J.transpose();
 
   if (reverse)
-    icov = JT*cov*J;                              // ‹t‰ñ“]•ÏŠ·
+    icov = JT*cov*J;                              // é€†å›è»¢å¤‰æ›
   else
-    icov = J*cov*JT;                              // ‰ñ“]•ÏŠ·
+    icov = J*cov*JT;                              // å›è»¢å¤‰æ›
 }

--- a/framework/CovarianceCalculator.h
+++ b/framework/CovarianceCalculator.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -20,14 +20,14 @@
 #include "LPoint2D.h"
 #include "Pose2D.h"
 
-// ICP‚É‚æ‚é„’è’l‚Ì‹¤•ªUA‚¨‚æ‚ÑAƒIƒhƒƒgƒŠ‚É‚æ‚é„’è’l‚Ì‹¤•ªU‚ğŒvZ‚·‚éB
+// ICPã«ã‚ˆã‚‹æ¨å®šå€¤ã®å…±åˆ†æ•£ã€ãŠã‚ˆã³ã€ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹æ¨å®šå€¤ã®å…±åˆ†æ•£ã‚’è¨ˆç®—ã™ã‚‹ã€‚
 class CovarianceCalculator
 {
 private:
-  double dd;                      // ”’l”÷•ª‚Ì‚İ
-  double da;                      // ”’l”÷•ª‚Ì‚İ
-  double a1;                      // ƒIƒhƒƒgƒŠ‹¤•ªU‚ÌŒW”
-  double a2;                      // ƒIƒhƒƒgƒŠ‹¤•ªU‚ÌŒW”
+  double dd;                      // æ•°å€¤å¾®åˆ†ã®åˆ»ã¿
+  double da;                      // æ•°å€¤å¾®åˆ†ã®åˆ»ã¿
+  double a1;                      // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå…±åˆ†æ•£ã®ä¿‚æ•°
+  double a2;                      // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå…±åˆ†æ•£ã®ä¿‚æ•°
 
 public:
   CovarianceCalculator() : dd(0.00001), da(0.00001) {

--- a/framework/DataAssociator.h
+++ b/framework/DataAssociator.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,8 +24,8 @@
 class DataAssociator
 {
 public:
-  std::vector<const LPoint2D*> curLps;            // ‘Î‰‚ª‚Æ‚ê‚½Œ»İƒXƒLƒƒƒ“‚Ì“_ŒQ
-  std::vector<const LPoint2D*> refLps;            // ‘Î‰‚ª‚Æ‚ê‚½QÆƒXƒLƒƒƒ“‚Ì“_ŒQ
+  std::vector<const LPoint2D*> curLps;            // å¯¾å¿œãŒã¨ã‚ŒãŸç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤
+  std::vector<const LPoint2D*> refLps;            // å¯¾å¿œãŒã¨ã‚ŒãŸå‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤
 
   DataAssociator() {
   }

--- a/framework/LPoint2D.h
+++ b/framework/LPoint2D.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,17 +24,17 @@ struct Vector2D
 
 ////////////////////////
 
-enum ptype {UNKNOWN=0, LINE=1, CORNER=2, ISOLATE=3};    // “_‚Ìƒ^ƒCƒvF–¢’mA’¼üAƒR[ƒiAŒÇ—§
+enum ptype {UNKNOWN=0, LINE=1, CORNER=2, ISOLATE=3};    // ç‚¹ã®ã‚¿ã‚¤ãƒ—ï¼šæœªçŸ¥ã€ç›´ç·šã€ã‚³ãƒ¼ãƒŠã€å­¤ç«‹
 
 struct LPoint2D
 {
-  int sid;                 // ƒtƒŒ[ƒ€”Ô†iƒXƒLƒƒƒ“”Ô†j
-  double x;                // ˆÊ’ux
-  double y;                // ˆÊ’uy
-  double nx;               // –@üƒxƒNƒgƒ‹
-  double ny;               // –@üƒxƒNƒgƒ‹
-  double atd;              // —İÏ‘–s‹——£(accumulated travel distance)
-  ptype type;              // “_‚Ìƒ^ƒCƒv
+  int sid;                 // ãƒ•ãƒ¬ãƒ¼ãƒ ç•ªå·ï¼ˆã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ï¼‰
+  double x;                // ä½ç½®x
+  double y;                // ä½ç½®y
+  double nx;               // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«
+  double ny;               // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«
+  double atd;              // ç´¯ç©èµ°è¡Œè·é›¢(accumulated travel distance)
+  ptype type;              // ç‚¹ã®ã‚¿ã‚¤ãƒ—
 
   LPoint2D() : sid(-1), x(0), y(0) {
     init();
@@ -67,14 +67,14 @@ struct LPoint2D
     y = _y;
   }
 
-  // range‚Æangle‚©‚çxy‚ğ‹‚ß‚é(‰EèŒn)
+  // rangeã¨angleã‹ã‚‰xyã‚’æ±‚ã‚ã‚‹(å³æ‰‹ç³»)
   void calXY(double range, double angle) {
     double a = DEG2RAD(angle);
     x = range*cos(a);
     y = range*sin(a);
   }
 
-  // range‚Æangle‚©‚çxy‚ğ‹‚ß‚é(¶èŒnj
+  // rangeã¨angleã‹ã‚‰xyã‚’æ±‚ã‚ã‚‹(å·¦æ‰‹ç³»ï¼‰
   void calXYi(double range, double angle) {
     double a = DEG2RAD(angle);
     x = range*cos(a);

--- a/framework/LoopDetector.cpp
+++ b/framework/LoopDetector.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,7 +18,7 @@ using namespace std;
 
 ////////////
 
-// ƒ‹[ƒvŒŸo‚Ìƒ_ƒ~[ŠÖ”
+// ãƒ«ãƒ¼ãƒ—æ¤œå‡ºã®ãƒ€ãƒŸãƒ¼é–¢æ•°
 bool LoopDetector::detectLoop(Scan2D *curScan, Pose2D &curPose, int cnt) {
   return(false);
 }

--- a/framework/LoopDetector.h
+++ b/framework/LoopDetector.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,15 +24,15 @@
 
 ///////
 
-// ƒ‹[ƒvƒA[ƒNİ’èî•ñ
+// ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯è¨­å®šæƒ…å ±
 struct LoopInfo
 {
-  bool arcked;                   // ‚·‚Å‚Éƒ|[ƒYƒA[ƒN‚ğ’£‚Á‚½‚©
-  int curId;                     // Œ»İƒL[ƒtƒŒ[ƒ€idiƒXƒLƒƒƒ“j
-  int refId;                     // QÆƒL[ƒtƒŒ[ƒ€idiƒXƒLƒƒƒ“C‚Ü‚½‚ÍCLocalGridMap2Dj
-  Pose2D pose;                   // Œ»İƒL[ƒtƒŒ[ƒ€‚ªQÆƒL[ƒtƒŒ[ƒ€‚Éƒ}ƒbƒ`‚·‚éƒOƒ[ƒoƒ‹p¨iGridƒx[ƒX‚Ìê‡‚Í‹tj
-  double score;                  // ICPƒ}ƒbƒ`ƒ“ƒOƒXƒRƒA
-  Eigen::Matrix3d cov;           // ‹¤•ªU
+  bool arcked;                   // ã™ã§ã«ãƒãƒ¼ã‚ºã‚¢ãƒ¼ã‚¯ã‚’å¼µã£ãŸã‹
+  int curId;                     // ç¾åœ¨ã‚­ãƒ¼ãƒ•ãƒ¬ãƒ¼ãƒ idï¼ˆã‚¹ã‚­ãƒ£ãƒ³ï¼‰
+  int refId;                     // å‚ç…§ã‚­ãƒ¼ãƒ•ãƒ¬ãƒ¼ãƒ idï¼ˆã‚¹ã‚­ãƒ£ãƒ³ï¼Œã¾ãŸã¯ï¼ŒLocalGridMap2Dï¼‰
+  Pose2D pose;                   // ç¾åœ¨ã‚­ãƒ¼ãƒ•ãƒ¬ãƒ¼ãƒ ãŒå‚ç…§ã‚­ãƒ¼ãƒ•ãƒ¬ãƒ¼ãƒ ã«ãƒãƒƒãƒã™ã‚‹ã‚°ãƒ­ãƒ¼ãƒãƒ«å§¿å‹¢ï¼ˆGridãƒ™ãƒ¼ã‚¹ã®å ´åˆã¯é€†ï¼‰
+  double score;                  // ICPãƒãƒƒãƒãƒ³ã‚°ã‚¹ã‚³ã‚¢
+  Eigen::Matrix3d cov;           // å…±åˆ†æ•£
 
   LoopInfo() : arcked(false), curId(-1), refId(-1), score(-1) {
   }
@@ -47,7 +47,7 @@ struct LoopInfo
 
 //////////////
 
-// ƒfƒoƒbƒO—pƒf[ƒ^
+// ãƒ‡ãƒãƒƒã‚°ç”¨ãƒ‡ãƒ¼ã‚¿
 struct LoopMatch
 {
   Scan2D curScan;
@@ -69,8 +69,8 @@ struct LoopMatch
 class LoopDetector
 {
 protected:  
-  PoseGraph *pg;                               // ƒ|[ƒYƒOƒ‰ƒt
-  std::vector<LoopMatch> loopMatches;          // ƒfƒoƒbƒO—p
+  PoseGraph *pg;                               // ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•
+  std::vector<LoopMatch> loopMatches;          // ãƒ‡ãƒãƒƒã‚°ç”¨
 
 public:
   LoopDetector() {
@@ -81,7 +81,7 @@ public:
 
 ////////
 
-  // ƒfƒoƒbƒO—p
+  // ãƒ‡ãƒãƒƒã‚°ç”¨
   std::vector<LoopMatch> &getLoopMatches() {
     return(loopMatches);
   }

--- a/framework/MyUtil.cpp
+++ b/framework/MyUtil.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -20,7 +20,7 @@ using namespace Eigen;
 
 /////////
 
-// Šp“x‚Ì‰ÁZB-180‚©‚ç180‚É³‹K‰»
+// è§’åº¦ã®åŠ ç®—ã€‚-180ã‹ã‚‰180ã«æ­£è¦åŒ–
 int MyUtil::add(int a1, int a2) {
   int sum = a1 + a2;
   if (sum < -180)
@@ -31,7 +31,7 @@ int MyUtil::add(int a1, int a2) {
   return(sum);
 }
 
-// Šp“x‚Ì‰ÁZB-180‚©‚ç180‚É³‹K‰»
+// è§’åº¦ã®åŠ ç®—ã€‚-180ã‹ã‚‰180ã«æ­£è¦åŒ–
 double MyUtil::add(double a1, double a2) {
   double sum = a1 + a2;
   if (sum < -180)
@@ -42,7 +42,7 @@ double MyUtil::add(double a1, double a2) {
   return(sum);
 }
 
-// Šp“x‚Ì‰ÁZiƒ‰ƒWƒAƒ“jB-pi‚©‚çpi‚É³‹K‰»
+// è§’åº¦ã®åŠ ç®—ï¼ˆãƒ©ã‚¸ã‚¢ãƒ³ï¼‰ã€‚-piã‹ã‚‰piã«æ­£è¦åŒ–
 double MyUtil::addR(double a1, double a2) {
   double sum = a1 + a2;
   if (sum < -M_PI)
@@ -55,7 +55,7 @@ double MyUtil::addR(double a1, double a2) {
 
 ////////////
 
-// SVD‚ğ—p‚¢‚½‹ts—ñŒvZ
+// SVDã‚’ç”¨ã„ãŸé€†è¡Œåˆ—è¨ˆç®—
 Eigen::Matrix3d MyUtil::svdInverse(const Matrix3d &A) {
   size_t m = A.rows();
   size_t n = A.cols();
@@ -68,7 +68,7 @@ Eigen::Matrix3d MyUtil::svdInverse(const Matrix3d &A) {
 
   MatrixXd M1(m, n);
   for (size_t i=0; i<n; i++) {
-//    if (eS[i] < 1.0E-10)                   // A‚ªSingular‚©‚Ç‚¤‚©‚Ìƒ`ƒFƒbƒNB¡‰ñ‚Í‚µ‚È‚¢
+//    if (eS[i] < 1.0E-10)                   // AãŒSingularã‹ã©ã†ã‹ã®ãƒã‚§ãƒƒã‚¯ã€‚ä»Šå›ã¯ã—ãªã„
 //      return;
     for (size_t j=0; j<n; j++) {
       M1(i,j) = eU(j,i)/eS[i];
@@ -89,7 +89,7 @@ Eigen::Matrix3d MyUtil::svdInverse(const Matrix3d &A) {
 
 /////////
 
-// 2Ÿ³•ûs—ñ‚ÌŒÅ—L’l•ª‰ğ
+// 2æ¬¡æ­£æ–¹è¡Œåˆ—ã®å›ºæœ‰å€¤åˆ†è§£
 void MyUtil::calEigen2D( double (*mat)[2], double *vals, double *vec1, double *vec2) {
   double a = mat[0][0];
   double b = mat[0][1];
@@ -99,23 +99,23 @@ void MyUtil::calEigen2D( double (*mat)[2], double *vals, double *vec1, double *v
   double B = sqrt((a+d)*(a+d) - 4*(a*d-b*c));
   double x1 = ((a+d) + B)/2;
   double x2 = ((a+d) - B)/2;
-  vals[0] = x1;                    // ŒÅ—L’l
+  vals[0] = x1;                    // å›ºæœ‰å€¤
   vals[1] = x2;
 
   double m00 = a-x1;
   double m01 = b;
   double L = sqrt(m00*m00 + m01*m01);
-  vec1[0] = m01/L;                 // ŒÅ—LƒxƒNƒgƒ‹
+  vec1[0] = m01/L;                 // å›ºæœ‰ãƒ™ã‚¯ãƒˆãƒ«
   vec1[1] = -m00/L;
 
   m00 = a-x2;
   m01 = b;
   L = sqrt(m00*m00 + m01*m01);
-  vec2[0] = m01/L;                 // ŒÅ—LƒxƒNƒgƒ‹
+  vec2[0] = m01/L;                 // å›ºæœ‰ãƒ™ã‚¯ãƒˆãƒ«
   vec2[1] = -m00/L;
 
 /*
-  // ŒŸZ
+  // æ¤œç®—
   double ax1 = a*vec1[0] + b*vec1[1];
   double ax2 = x1*vec1[0];
   double ay1 = c*vec1[0] + d*vec1[1];

--- a/framework/MyUtil.h
+++ b/framework/MyUtil.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -20,15 +20,15 @@
 #include <Eigen/Eigen>
 
 #ifndef M_PI
-#define M_PI 3.14159265358979             // ‰~ü—¦
+#define M_PI 3.14159265358979             // å††å‘¨ç‡
 #endif
 
 #ifndef NULL
-#define NULL 0                     // Šî–{“I‚É‚ÍAC++11‚Ìnullptr‚ğg‚¤
+#define NULL 0                     // åŸºæœ¬çš„ã«ã¯ã€C++11ã®nullptrã‚’ä½¿ã†
 #endif
 
-#define DEG2RAD(x) ((x)*M_PI/180)  // “x‚©‚çƒ‰ƒWƒAƒ“
-#define RAD2DEG(x) ((x)*180/M_PI)  // ƒ‰ƒWƒAƒ“‚©‚ç“x
+#define DEG2RAD(x) ((x)*M_PI/180)  // åº¦ã‹ã‚‰ãƒ©ã‚¸ã‚¢ãƒ³
+#define RAD2DEG(x) ((x)*180/M_PI)  // ãƒ©ã‚¸ã‚¢ãƒ³ã‹ã‚‰åº¦
 
 typedef unsigned char uchar;
 

--- a/framework/NNGridTable.cpp
+++ b/framework/NNGridTable.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,28 +18,28 @@ using namespace std;
 
 ////////////
 
-// Šiqƒe[ƒuƒ‹‚ÉƒXƒLƒƒƒ““_lp‚ğ“o˜^‚·‚é
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚¹ã‚­ãƒ£ãƒ³ç‚¹lpã‚’ç™»éŒ²ã™ã‚‹
 void NNGridTable::addPoint(const LPoint2D *lp) {
-  // ƒe[ƒuƒ‹ŒŸõ‚ÌƒCƒ“ƒfƒbƒNƒXŒvZB‚Ü‚¸A‘ÎÛ—Ìˆæ“à‚É‚ ‚é‚©ƒ`ƒFƒbƒN‚·‚éB
+  // ãƒ†ãƒ¼ãƒ–ãƒ«æ¤œç´¢ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹è¨ˆç®—ã€‚ã¾ãšã€å¯¾è±¡é ˜åŸŸå†…ã«ã‚ã‚‹ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
   int xi = static_cast<int>(lp->x/csize) + tsize;
-  if (xi < 0 || xi > 2*tsize)                      // ‘ÎÛ—Ìˆæ‚ÌŠO
+  if (xi < 0 || xi > 2*tsize)                      // å¯¾è±¡é ˜åŸŸã®å¤–
     return;
   int yi = static_cast<int>(lp->y/csize) + tsize;
-  if (yi < 0 || yi > 2*tsize)                      // ‘ÎÛ—Ìˆæ‚ÌŠO
+  if (yi < 0 || yi > 2*tsize)                      // å¯¾è±¡é ˜åŸŸã®å¤–
     return;
 
-  size_t idx = static_cast<size_t>(yi*(2*tsize +1) + xi);   // ƒe[ƒuƒ‹‚ÌƒCƒ“ƒfƒbƒNƒX
-  table[idx].lps.push_back(lp);                             // –Ú“I‚ÌƒZƒ‹‚É“ü‚ê‚é
+  size_t idx = static_cast<size_t>(yi*(2*tsize +1) + xi);   // ãƒ†ãƒ¼ãƒ–ãƒ«ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+  table[idx].lps.push_back(lp);                             // ç›®çš„ã®ã‚»ãƒ«ã«å…¥ã‚Œã‚‹
 }
 
 ///////////
 
-// ƒXƒLƒƒƒ““_clp‚ğpredPose‚ÅÀ•W•ÏŠ·‚µ‚½ˆÊ’u‚ÉÅ‚à‹ß‚¢“_‚ğŠiqƒe[ƒuƒ‹‚©‚çŒ©‚Â‚¯‚é
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹clpã‚’predPoseã§åº§æ¨™å¤‰æ›ã—ãŸä½ç½®ã«æœ€ã‚‚è¿‘ã„ç‚¹ã‚’æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã‹ã‚‰è¦‹ã¤ã‘ã‚‹
 const LPoint2D *NNGridTable::findClosestPoint(const LPoint2D *clp, const Pose2D &predPose) {
-  LPoint2D glp;                           // clp‚Ì—\‘ªˆÊ’u
-  predPose.globalPoint(*clp, glp);         // relPose‚ÅÀ•W•ÏŠ·
+  LPoint2D glp;                           // clpã®äºˆæ¸¬ä½ç½®
+  predPose.globalPoint(*clp, glp);         // relPoseã§åº§æ¨™å¤‰æ›
 
-  // clp‚Ìƒe[ƒuƒ‹ƒCƒ“ƒfƒbƒNƒXB‘ÎÛ—Ìˆæ“à‚É‚ ‚é‚©ƒ`ƒFƒbƒN‚·‚éB
+  // clpã®ãƒ†ãƒ¼ãƒ–ãƒ«ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ã€‚å¯¾è±¡é ˜åŸŸå†…ã«ã‚ã‚‹ã‹ãƒã‚§ãƒƒã‚¯ã™ã‚‹ã€‚
   int cxi = static_cast<int>(glp.x/csize) + tsize;
   if (cxi < 0 || cxi > 2*tsize)
     return(nullptr);
@@ -47,30 +47,30 @@ const LPoint2D *NNGridTable::findClosestPoint(const LPoint2D *clp, const Pose2D 
   if (cyi < 0 || cyi > 2*tsize)
     return(nullptr);
 
-  size_t pn=0;                            // ’T‚µ‚½ƒZƒ‹“à‚Ì“_‚Ì‘”BŠm”F—p
+  size_t pn=0;                            // æ¢ã—ãŸã‚»ãƒ«å†…ã®ç‚¹ã®ç·æ•°ã€‚ç¢ºèªç”¨
   double dmin=1000000;
-  const LPoint2D *lpmin = nullptr;        // Å‚à‹ß‚¢“_i–Ú“I‚Ì“_j
-  double dthre=0.2;                       // ‚±‚ê‚æ‚è‰“‚¢“_‚ÍœŠO‚·‚é[m]
+  const LPoint2D *lpmin = nullptr;        // æœ€ã‚‚è¿‘ã„ç‚¹ï¼ˆç›®çš„ã®ç‚¹ï¼‰
+  double dthre=0.2;                       // ã“ã‚Œã‚ˆã‚Šé ã„ç‚¹ã¯é™¤å¤–ã™ã‚‹[m]
   int R=static_cast<int>(dthre/csize);
 
-  // }Rl•û‚ğ’T‚·
+  // Â±Rå››æ–¹ã‚’æ¢ã™
   for (int i=-R; i<=R; i++) {
-    int yi = cyi+i;                       // cyi‚©‚çL‚°‚é
+    int yi = cyi+i;                       // cyiã‹ã‚‰åºƒã’ã‚‹
     if (yi < 0 || yi > 2*tsize)
       continue;
     for (int j=-R; j<=R; j++) {
-      int xi = cxi+j;                     // cxi‚©‚çL‚°‚é
+      int xi = cxi+j;                     // cxiã‹ã‚‰åºƒã’ã‚‹
       if (xi < 0 || xi > 2*tsize)
         continue;
 
-      size_t idx = yi*(2*tsize+1) + xi;             // ƒe[ƒuƒ‹ƒCƒ“ƒfƒbƒNƒX
-      NNGridCell &cell = table[idx];                // ‚»‚ÌƒZƒ‹
-      vector<const LPoint2D*> &lps = cell.lps;      // ƒZƒ‹‚ª‚à‚ÂƒXƒLƒƒƒ““_ŒQ
+      size_t idx = yi*(2*tsize+1) + xi;             // ãƒ†ãƒ¼ãƒ–ãƒ«ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+      NNGridCell &cell = table[idx];                // ãã®ã‚»ãƒ«
+      vector<const LPoint2D*> &lps = cell.lps;      // ã‚»ãƒ«ãŒã‚‚ã¤ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
       for (size_t k=0; k<lps.size(); k++) {
         const LPoint2D *lp = lps[k];
         double d = (lp->x - glp.x)*(lp->x - glp.x) + (lp->y - glp.y)*(lp->y - glp.y);
 
-        if (d <= dthre*dthre && d < dmin) {         // dthre“à‚Å‹——£‚ªÅ¬‚Æ‚È‚é“_‚ğ•Û‘¶
+        if (d <= dthre*dthre && d < dmin) {         // dthreå†…ã§è·é›¢ãŒæœ€å°ã¨ãªã‚‹ç‚¹ã‚’ä¿å­˜
           dmin = d;
           lpmin = lp;
         }
@@ -78,51 +78,51 @@ const LPoint2D *NNGridTable::findClosestPoint(const LPoint2D *clp, const Pose2D 
       pn += lps.size();
     }
   }
-//  printf("pn=%d\n", pn);                 // ’T‚µ‚½ƒZƒ‹“à‚Ì“_‚Ì‘”BŠm”F—p
+//  printf("pn=%d\n", pn);                 // æ¢ã—ãŸã‚»ãƒ«å†…ã®ç‚¹ã®ç·æ•°ã€‚ç¢ºèªç”¨
 
   return(lpmin);
 }
 
 ////////////
 
-// Šiqƒe[ƒuƒ‹‚ÌŠeƒZƒ‹‚Ì‘ã•\“_‚ğì‚Á‚Äps‚ÉŠi”[‚·‚éB
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã®å„ã‚»ãƒ«ã®ä»£è¡¨ç‚¹ã‚’ä½œã£ã¦psã«æ ¼ç´ã™ã‚‹ã€‚
 void NNGridTable::makeCellPoints(int nthre, vector<LPoint2D> &ps) {
-  // Œ»ó‚ÍƒZƒ‹“à‚ÌŠe“_‚ÌƒXƒLƒƒƒ“”Ô†‚Ì•½‹Ï‚ğ‚Æ‚éB
-  // ƒXƒLƒƒƒ“”Ô†‚ÌÅV’l‚ğ‚Æ‚éê‡‚ÍA‚»‚Ì•”•ª‚ÌƒRƒƒ“ƒg‚ğ‚Í‚¸‚µA
-  // •½‹Ï‚Æ‚éê‡i2sj‚ğƒRƒƒ“ƒgƒAƒEƒg‚·‚éB
+  // ç¾çŠ¶ã¯ã‚»ãƒ«å†…ã®å„ç‚¹ã®ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®å¹³å‡ã‚’ã¨ã‚‹ã€‚
+  // ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®æœ€æ–°å€¤ã‚’ã¨ã‚‹å ´åˆã¯ã€ãã®éƒ¨åˆ†ã®ã‚³ãƒ¡ãƒ³ãƒˆã‚’ã¯ãšã—ã€
+  // å¹³å‡ã¨ã‚‹å ´åˆï¼ˆ2è¡Œï¼‰ã‚’ã‚³ãƒ¡ãƒ³ãƒˆã‚¢ã‚¦ãƒˆã™ã‚‹ã€‚
 
-  size_t nn=0;                           // ƒe[ƒuƒ‹“à‚Ì‘SƒZƒ‹”BŠm”F—p
+  size_t nn=0;                           // ãƒ†ãƒ¼ãƒ–ãƒ«å†…ã®å…¨ã‚»ãƒ«æ•°ã€‚ç¢ºèªç”¨
   for (size_t i=0; i<table.size(); i++) {
-    vector<const LPoint2D*> &lps = table[i].lps;      // ƒZƒ‹‚ÌƒXƒLƒƒƒ““_ŒQ
+    vector<const LPoint2D*> &lps = table[i].lps;      // ã‚»ãƒ«ã®ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
     nn += lps.size();
-    if (lps.size() >= nthre) {           // “_”‚ªnthre‚æ‚è‘½‚¢ƒZƒ‹‚¾‚¯ˆ—‚·‚é
-      double gx=0, gy=0;                 // “_ŒQ‚ÌdSˆÊ’u
-      double nx=0, ny=0;                 // “_ŒQ‚Ì–@üƒxƒNƒgƒ‹‚Ì•½‹Ï
+    if (lps.size() >= nthre) {           // ç‚¹æ•°ãŒnthreã‚ˆã‚Šå¤šã„ã‚»ãƒ«ã ã‘å‡¦ç†ã™ã‚‹
+      double gx=0, gy=0;                 // ç‚¹ç¾¤ã®é‡å¿ƒä½ç½®
+      double nx=0, ny=0;                 // ç‚¹ç¾¤ã®æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã®å¹³å‡
       int sid=0;
       for (size_t j=0; j<lps.size(); j++) {
         const LPoint2D *lp = lps[j];
-        gx += lp->x;                     // ˆÊ’u‚ğ—İÏ
+        gx += lp->x;                     // ä½ç½®ã‚’ç´¯ç©
         gy += lp->y;
-        nx += lp->nx;                    // –@üƒxƒNƒgƒ‹¬•ª‚ğ—İÏ
+        nx += lp->nx;                    // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«æˆåˆ†ã‚’ç´¯ç©
         ny += lp->ny;
-        sid += lp->sid;                  // ƒXƒLƒƒƒ“”Ô†‚Ì•½‹Ï‚Æ‚éê‡
-//        if (lp->sid > sid)             // ƒXƒLƒƒƒ“”Ô†‚ÌÅV’l‚Æ‚éê‡
+        sid += lp->sid;                  // ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®å¹³å‡ã¨ã‚‹å ´åˆ
+//        if (lp->sid > sid)             // ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®æœ€æ–°å€¤ã¨ã‚‹å ´åˆ
 //          sid = lp->sid;
 //        printf("sid=%d\n", lp->sid);
       }
-      gx /= lps.size();                  // •½‹Ï
+      gx /= lps.size();                  // å¹³å‡
       gy /= lps.size();
       double L = sqrt(nx*nx + ny*ny);
-      nx /=  L;                          // •½‹Ïi³‹K‰»j
+      nx /=  L;                          // å¹³å‡ï¼ˆæ­£è¦åŒ–ï¼‰
       ny /=  L;
-      sid /= lps.size();                 // ƒXƒLƒƒƒ“”Ô†‚Ì•½‹Ï‚Æ‚éê‡
+      sid /= lps.size();                 // ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã®å¹³å‡ã¨ã‚‹å ´åˆ
 
-      LPoint2D newLp(sid, gx, gy);       // ƒZƒ‹‚Ì‘ã•\“_‚ğ¶¬
-      newLp.setNormal(nx, ny);           // –@üƒxƒNƒgƒ‹İ’è
-      newLp.setType(LINE);               // ƒ^ƒCƒv‚Í’¼ü‚É‚·‚é
-      ps.emplace_back(newLp);            // ps‚É’Ç‰Á
+      LPoint2D newLp(sid, gx, gy);       // ã‚»ãƒ«ã®ä»£è¡¨ç‚¹ã‚’ç”Ÿæˆ
+      newLp.setNormal(nx, ny);           // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«è¨­å®š
+      newLp.setType(LINE);               // ã‚¿ã‚¤ãƒ—ã¯ç›´ç·šã«ã™ã‚‹
+      ps.emplace_back(newLp);            // psã«è¿½åŠ 
     }
   }
 
-//  printf("nn=%d\n", nn);               // ƒe[ƒuƒ‹“à‚Ì‘SƒZƒ‹”BŠm”F—p
+//  printf("nn=%d\n", nn);               // ãƒ†ãƒ¼ãƒ–ãƒ«å†…ã®å…¨ã‚»ãƒ«æ•°ã€‚ç¢ºèªç”¨
 }

--- a/framework/NNGridTable.h
+++ b/framework/NNGridTable.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -21,30 +21,30 @@
 
 struct NNGridCell
 {
-  std::vector<const LPoint2D*> lps;         // ‚±‚ÌƒZƒ‹‚ÉŠi”[‚³‚ê‚½ƒXƒLƒƒƒ““_ŒQ
+  std::vector<const LPoint2D*> lps;         // ã“ã®ã‚»ãƒ«ã«æ ¼ç´ã•ã‚ŒãŸã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
 
   void clear() {
-    lps.clear();                            // ‹ó‚É‚·‚é
+    lps.clear();                            // ç©ºã«ã™ã‚‹
   }
 };
 
 ///////
 
-// Šiqƒe[ƒuƒ‹
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«
 class NNGridTable
 {
 private:
-  double csize;                       // ƒZƒ‹ƒTƒCƒY[m]
-  double rsize;                       // ‘ÎÛ—Ìˆæ‚ÌƒTƒCƒY[m]B³•ûŒ`‚Ì1•Ó‚Ì”¼•ªB
-  int tsize;                          // ƒe[ƒuƒ‹ƒTƒCƒY‚Ì”¼•ª
-  std::vector<NNGridCell> table;      // ƒe[ƒuƒ‹–{‘Ì
+  double csize;                       // ã‚»ãƒ«ã‚µã‚¤ã‚º[m]
+  double rsize;                       // å¯¾è±¡é ˜åŸŸã®ã‚µã‚¤ã‚º[m]ã€‚æ­£æ–¹å½¢ã®1è¾ºã®åŠåˆ†ã€‚
+  int tsize;                          // ãƒ†ãƒ¼ãƒ–ãƒ«ã‚µã‚¤ã‚ºã®åŠåˆ†
+  std::vector<NNGridCell> table;      // ãƒ†ãƒ¼ãƒ–ãƒ«æœ¬ä½“
 
 public:
-  NNGridTable() : csize(0.05), rsize(40){            // ƒZƒ‹5cmA‘ÎÛ—Ìˆæ40x2ml•û
-    tsize = static_cast<int>(rsize/csize);           // ƒe[ƒuƒ‹ƒTƒCƒY‚Ì”¼•ª
-    size_t w = static_cast<int>(2*tsize+1);          // ƒe[ƒuƒ‹ƒTƒCƒY
-    table.resize(w*w);                               // —ÌˆæŠm•Û
-    clear();                                         // table‚Ì‰Šú‰»
+  NNGridTable() : csize(0.05), rsize(40){            // ã‚»ãƒ«5cmã€å¯¾è±¡é ˜åŸŸ40x2må››æ–¹
+    tsize = static_cast<int>(rsize/csize);           // ãƒ†ãƒ¼ãƒ–ãƒ«ã‚µã‚¤ã‚ºã®åŠåˆ†
+    size_t w = static_cast<int>(2*tsize+1);          // ãƒ†ãƒ¼ãƒ–ãƒ«ã‚µã‚¤ã‚º
+    table.resize(w*w);                               // é ˜åŸŸç¢ºä¿
+    clear();                                         // tableã®åˆæœŸåŒ–
   }
 
   ~NNGridTable() {
@@ -52,7 +52,7 @@ public:
   
   void clear() {
     for (size_t i=0; i<table.size(); i++)
-      table[i].clear();                         // ŠeƒZƒ‹‚ğ‹ó‚É‚·‚é
+      table[i].clear();                         // å„ã‚»ãƒ«ã‚’ç©ºã«ã™ã‚‹
   }
   
 ////////////

--- a/framework/P2oDriver2D.cpp
+++ b/framework/P2oDriver2D.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -19,22 +19,22 @@ using namespace std;
 
 ////////
 
-// kslam‚ğ—p‚¢‚Äƒ|[ƒYƒOƒ‰ƒtpg‚ğƒ|[ƒY’²®‚µA‚»‚ÌŒ‹‰Ê‚Ìƒƒ{ƒbƒg‹OÕ‚ğnewPoses‚ÉŠi”[‚·‚éB
+// kslamã‚’ç”¨ã„ã¦ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•pgã‚’ãƒãƒ¼ã‚ºèª¿æ•´ã—ã€ãã®çµæœã®ãƒ­ãƒœãƒƒãƒˆè»Œè·¡ã‚’newPosesã«æ ¼ç´ã™ã‚‹ã€‚
 void P2oDriver2D::doP2o( PoseGraph &pg, vector<Pose2D> &newPoses, int N) {
-  vector<PoseNode*> &nodes = pg.nodes;                        // ƒ|[ƒYƒm[ƒh
-  vector<PoseArc*> &arcs = pg.arcs;                           // ƒ|[ƒYƒA[ƒN
+  vector<PoseNode*> &nodes = pg.nodes;                        // ãƒãƒ¼ã‚ºãƒãƒ¼ãƒ‰
+  vector<PoseArc*> &arcs = pg.arcs;                           // ãƒãƒ¼ã‚ºã‚¢ãƒ¼ã‚¯
 
-  // ƒ|[ƒYƒm[ƒh‚ğp2o—p‚É•ÏŠ·
-  vector<p2o::Pose2D> pnodes;                                  // p2o‚Ìƒ|[ƒYƒm[ƒhW‡
+  // ãƒãƒ¼ã‚ºãƒãƒ¼ãƒ‰ã‚’p2oç”¨ã«å¤‰æ›
+  vector<p2o::Pose2D> pnodes;                                  // p2oã®ãƒãƒ¼ã‚ºãƒãƒ¼ãƒ‰é›†åˆ
   for (size_t i=0; i<nodes.size(); i++) {
     PoseNode *node = nodes[i];
-    Pose2D pose = node->pose;                                  // ƒm[ƒh‚ÌˆÊ’u
-    pnodes.push_back(p2o::Pose2D(pose.tx, pose.ty, DEG2RAD(pose.th)));   // ˆÊ’u‚¾‚¯“ü‚ê‚é
+    Pose2D pose = node->pose;                                  // ãƒãƒ¼ãƒ‰ã®ä½ç½®
+    pnodes.push_back(p2o::Pose2D(pose.tx, pose.ty, DEG2RAD(pose.th)));   // ä½ç½®ã ã‘å…¥ã‚Œã‚‹
   }
 
 
-  // ƒ|[ƒYƒA[ƒN‚ğkslam—p‚É•ÏŠ·
-  p2o::Con2DVec pcons;                             // p2o‚Ìƒ|[ƒYƒA[ƒNW‡
+  // ãƒãƒ¼ã‚ºã‚¢ãƒ¼ã‚¯ã‚’kslamç”¨ã«å¤‰æ›
+  p2o::Con2DVec pcons;                             // p2oã®ãƒãƒ¼ã‚ºã‚¢ãƒ¼ã‚¯é›†åˆ
   for (size_t i=0; i<arcs.size(); i++) {
     PoseArc *arc = arcs[i];
     PoseNode *src = arc->src;
@@ -50,14 +50,14 @@ void P2oDriver2D::doP2o( PoseGraph &pg, vector<Pose2D> &newPoses, int N) {
     pcons.push_back(con);
   }
 
-//  printf("knodes.size=%lu, kcons.size=%lu\n", knodes.size(), kcons.size());    // Šm”F—p
+//  printf("knodes.size=%lu, kcons.size=%lu\n", knodes.size(), kcons.size());    // ç¢ºèªç”¨
 
-  p2o::Optimizer2D opt;                                          // p2oƒCƒ“ƒXƒ^ƒ“ƒX
-  std::vector<p2o::Pose2D> result = opt.optimizePath(pnodes, pcons, N);  // N‰ñÀs
+  p2o::Optimizer2D opt;                                          // p2oã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹
+  std::vector<p2o::Pose2D> result = opt.optimizePath(pnodes, pcons, N);  // Nå›å®Ÿè¡Œ
 
-   // Œ‹‰Ê‚ğnewPose‚ÉŠi”[‚·‚é
+   // çµæœã‚’newPoseã«æ ¼ç´ã™ã‚‹
   for (size_t i=0; i<result.size(); i++) {
-    p2o::Pose2D newPose = result[i];                                      // i”Ô–Ú‚Ìƒm[ƒh‚ÌC³‚³‚ê‚½ˆÊ’u
+    p2o::Pose2D newPose = result[i];                                      // iç•ªç›®ã®ãƒãƒ¼ãƒ‰ã®ä¿®æ­£ã•ã‚ŒãŸä½ç½®
     Pose2D pose(newPose.x, newPose.y, RAD2DEG(newPose.th));
     newPoses.emplace_back(pose);
   }

--- a/framework/P2oDriver2D.h
+++ b/framework/P2oDriver2D.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -26,7 +26,7 @@
 
 //////////
 
-// ƒ|[ƒYƒOƒ‰ƒtÅ“K‰»ƒ‰ƒCƒuƒ‰ƒŠkslam‚ğ‹N“®‚·‚éB
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•æœ€é©åŒ–ãƒ©ã‚¤ãƒ–ãƒ©ãƒªkslamã‚’èµ·å‹•ã™ã‚‹ã€‚
 class P2oDriver2D
 {
 public:

--- a/framework/PointCloudMap.h
+++ b/framework/PointCloudMap.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -21,23 +21,23 @@
 #include "Pose2D.h"
 #include "Scan2D.h"
 
-// “_ŒQ’n}‚ÌŠî’êƒNƒ‰ƒX
+// ç‚¹ç¾¤åœ°å›³ã®åŸºåº•ã‚¯ãƒ©ã‚¹
 class PointCloudMap
 {
 public:
-  static const int MAX_POINT_NUM=1000000;          // globalMap‚ÌÅ‘å“_”
+  static const int MAX_POINT_NUM=1000000;          // globalMapã®æœ€å¤§ç‚¹æ•°
 
-  int nthre;                                       // Šiqƒe[ƒuƒ‹ƒZƒ‹“_”è‡’l(GT‚ÆLP‚Ì‚İj
+  int nthre;                                       // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã‚»ãƒ«ç‚¹æ•°é–¾å€¤(GTã¨LPã®ã¿ï¼‰
 
-  std::vector<Pose2D> poses;                       // ƒƒ{ƒbƒg‹OÕ
-  Pose2D lastPose;                                 // ÅŒã‚É„’è‚µ‚½ƒƒ{ƒbƒgˆÊ’u
-  Scan2D lastScan;                                 // ÅŒã‚Éˆ—‚µ‚½ƒXƒLƒƒƒ“
+  std::vector<Pose2D> poses;                       // ãƒ­ãƒœãƒƒãƒˆè»Œè·¡
+  Pose2D lastPose;                                 // æœ€å¾Œã«æ¨å®šã—ãŸãƒ­ãƒœãƒƒãƒˆä½ç½®
+  Scan2D lastScan;                                 // æœ€å¾Œã«å‡¦ç†ã—ãŸã‚¹ã‚­ãƒ£ãƒ³
 
-  std::vector<LPoint2D> globalMap;                 // ‘S‘Ì’n}BŠÔˆø‚«Œã‚Ì“_
-  std::vector<LPoint2D> localMap;                  // Œ»İˆÊ’u‹ß–T‚Ì‹ÇŠ’n}BƒXƒLƒƒƒ“ƒ}ƒbƒ`ƒ“ƒO‚Ég‚¤
+  std::vector<LPoint2D> globalMap;                 // å…¨ä½“åœ°å›³ã€‚é–“å¼•ãå¾Œã®ç‚¹
+  std::vector<LPoint2D> localMap;                  // ç¾åœ¨ä½ç½®è¿‘å‚ã®å±€æ‰€åœ°å›³ã€‚ã‚¹ã‚­ãƒ£ãƒ³ãƒãƒƒãƒãƒ³ã‚°ã«ä½¿ã†
 
   PointCloudMap() : nthre(1) {
-    globalMap.reserve(MAX_POINT_NUM);              // Å‰‚ÉŠm•Û
+    globalMap.reserve(MAX_POINT_NUM);              // æœ€åˆã«ç¢ºä¿
   }
 
   ~PointCloudMap() {

--- a/framework/Pose2D.cpp
+++ b/framework/Pose2D.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -14,25 +14,25 @@
 
 #include "Pose2D.h"
 
-// ƒOƒ[ƒoƒ‹À•WŒn‚Å‚Ì“_p‚ğA©•ªiPose2Dj‚Ì‹ÇŠÀ•WŒn‚É•ÏŠ·
+// ã‚°ãƒ­ãƒ¼ãƒãƒ«åº§æ¨™ç³»ã§ã®ç‚¹pã‚’ã€è‡ªåˆ†ï¼ˆPose2Dï¼‰ã®å±€æ‰€åº§æ¨™ç³»ã«å¤‰æ›
 LPoint2D Pose2D::relativePoint(const LPoint2D &p) const {
   double dx = p.x - tx;
   double dy = p.y - ty;
-  double x = dx*Rmat[0][0] + dy*Rmat[1][0];  // ‰ñ“]‚Ì‹ts—ñ
+  double x = dx*Rmat[0][0] + dy*Rmat[1][0];  // å›è»¢ã®é€†è¡Œåˆ—
   double y = dx*Rmat[0][1] + dy*Rmat[1][1];
   return LPoint2D(p.sid, x, y);
 }
 
 ////////
 
-// ©•ªiPose2Dj‚Ì‹ÇŠÀ•WŒn‚Å‚Ì“_p‚ğAƒOƒ[ƒoƒ‹À•WŒn‚É•ÏŠ·
+// è‡ªåˆ†ï¼ˆPose2Dï¼‰ã®å±€æ‰€åº§æ¨™ç³»ã§ã®ç‚¹pã‚’ã€ã‚°ãƒ­ãƒ¼ãƒãƒ«åº§æ¨™ç³»ã«å¤‰æ›
 LPoint2D Pose2D::globalPoint(const LPoint2D &p) const {
   double x = Rmat[0][0]*p.x + Rmat[0][1]*p.y + tx;
   double y = Rmat[1][0]*p.x + Rmat[1][1]*p.y + ty;
   return LPoint2D(p.sid, x, y);
 }
 
-// ©•ªiPose2Dj‚Ì‹ÇŠÀ•WŒn‚Å‚Ì“_p‚ğAƒOƒ[ƒoƒ‹À•WŒn‚É•ÏŠ·‚µ‚Äpo‚É“ü‚ê‚é
+// è‡ªåˆ†ï¼ˆPose2Dï¼‰ã®å±€æ‰€åº§æ¨™ç³»ã§ã®ç‚¹pã‚’ã€ã‚°ãƒ­ãƒ¼ãƒãƒ«åº§æ¨™ç³»ã«å¤‰æ›ã—ã¦poã«å…¥ã‚Œã‚‹
 void Pose2D::globalPoint(const LPoint2D &pi, LPoint2D &po) const {
   po.x = Rmat[0][0]*pi.x + Rmat[0][1]*pi.y + tx;
   po.y = Rmat[1][0]*pi.x + Rmat[1][1]*pi.y + ty;
@@ -40,19 +40,19 @@ void Pose2D::globalPoint(const LPoint2D &pi, LPoint2D &po) const {
 
 ///////
 
-// Šî€À•WŒnbpose‚©‚çŒ©‚½Œ»À•WŒnnpose‚Ì‘Š‘ÎˆÊ’urelPose‚ğ‹‚ß‚éiInverse compounding operatorj
+// åŸºæº–åº§æ¨™ç³»bposeã‹ã‚‰è¦‹ãŸç¾åº§æ¨™ç³»nposeã®ç›¸å¯¾ä½ç½®relPoseã‚’æ±‚ã‚ã‚‹ï¼ˆInverse compounding operatorï¼‰
 void Pose2D::calRelativePose(const Pose2D &npose, const Pose2D &bpose, Pose2D &relPose) {
-  const double (*R0)[2] = bpose.Rmat;           // Šî€À•WŒn
-  const double (*R1)[2] = npose.Rmat;           // Œ»À•WŒn
-  double (*R2)[2] = relPose.Rmat;               // ‘Š‘ÎˆÊ’u
+  const double (*R0)[2] = bpose.Rmat;           // åŸºæº–åº§æ¨™ç³»
+  const double (*R1)[2] = npose.Rmat;           // ç¾åº§æ¨™ç³»
+  double (*R2)[2] = relPose.Rmat;               // ç›¸å¯¾ä½ç½®
 
-  // •Ài
+  // ä¸¦é€²
   double dx = npose.tx - bpose.tx;
   double dy = npose.ty - bpose.ty;
   relPose.tx = R0[0][0]*dx + R0[1][0]*dy;
   relPose.ty = R0[0][1]*dx + R0[1][1]*dy;
 
-  // ‰ñ“]
+  // å›è»¢
   double th = npose.th - bpose.th;
   if (th < -180)
     th += 360;
@@ -63,19 +63,19 @@ void Pose2D::calRelativePose(const Pose2D &npose, const Pose2D &bpose, Pose2D &r
   relPose.calRmat();
 }
 
-// Šî€À•WŒnbpose‚©‚ç‘Š‘ÎˆÊ’urelPose‚¾‚¯i‚ñ‚¾AÀ•WŒnnpose‚ğ‹‚ß‚éiCompounding operatorj
+// åŸºæº–åº§æ¨™ç³»bposeã‹ã‚‰ç›¸å¯¾ä½ç½®relPoseã ã‘é€²ã‚“ã ã€åº§æ¨™ç³»nposeã‚’æ±‚ã‚ã‚‹ï¼ˆCompounding operatorï¼‰
 void Pose2D::calGlobalPose(const Pose2D &relPose, const Pose2D &bpose, Pose2D &npose) {
-  const double (*R0)[2] = bpose.Rmat;           // Šî€À•WŒn
-  const double (*R1)[2] = relPose.Rmat;         // ‘Š‘ÎˆÊ’u
-  double (*R2)[2] = npose.Rmat;                 // VÀ•WŒn
+  const double (*R0)[2] = bpose.Rmat;           // åŸºæº–åº§æ¨™ç³»
+  const double (*R1)[2] = relPose.Rmat;         // ç›¸å¯¾ä½ç½®
+  double (*R2)[2] = npose.Rmat;                 // æ–°åº§æ¨™ç³»
 
-  // •Ài
+  // ä¸¦é€²
   double tx = relPose.tx;
   double ty = relPose.ty;
   npose.tx =  R0[0][0]*tx + R0[0][1]*ty + bpose.tx;
   npose.ty =  R0[1][0]*tx + R0[1][1]*ty + bpose.ty;
 
-  // Šp“x
+  // è§’åº¦
   double th = bpose.th + relPose.th;
   if (th < -180)
     th += 360;

--- a/framework/Pose2D.h
+++ b/framework/Pose2D.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -22,10 +22,10 @@
 
 struct Pose2D
 {
-  double tx;                           // •Àix
-  double ty;                           // •Àiy
-  double th;                           // ‰ñ“]Šp(“x)
-  double Rmat[2][2];                   // p¨‚Ì‰ñ“]s—ñ
+  double tx;                           // ä¸¦é€²x
+  double ty;                           // ä¸¦é€²y
+  double th;                           // å›è»¢è§’(åº¦)
+  double Rmat[2][2];                   // å§¿å‹¢ã®å›è»¢è¡Œåˆ—
 
   Pose2D() : tx(0), ty(0), th(0) {
     for(int i=0;i<2;i++) {

--- a/framework/PoseEstimatorICP.cpp
+++ b/framework/PoseEstimatorICP.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+п»ї/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -19,30 +19,30 @@ using namespace std;
 
 //////////////
 
-// Џ‰Љъ’linitPose‚р—^‚¦‚ДЃAICP‚Й‚ж‚иѓЌѓ{ѓbѓg€К’u‚Мђ„’и’lestPose‚р‹Ѓ‚Я‚й
+// е€ќжњџеЂ¤initPoseг‚’дёЋгЃ€гЃ¦гЂЃICPгЃ«г‚€г‚Љгѓ­гѓњгѓѓгѓ€дЅЌзЅ®гЃ®жЋЁе®љеЂ¤estPoseг‚’ж±‚г‚Ѓг‚‹
 double PoseEstimatorICP::estimatePose(Pose2D &initPose, Pose2D &estPose){
   boost::timer tim;
 
-  double evmin = HUGE_VAL;             // ѓRѓXѓgЌЕЏ¬’lЃBЏ‰Љъ’l‚Н‘е‚«‚­
-  double evthre = 0.000001;            // ѓRѓXѓg•П‰»и‡’lЃB•П‰»—К‚Є‚±‚к€И‰є‚И‚зЊJ‚и•Ф‚µЏI—№
-//  double evthre = 0.00000001;            // ѓRѓXѓg•П‰»и‡’lЃB•П‰»—К‚Є‚±‚к€И‰є‚И‚зЊJ‚и•Ф‚µЏI—№
+  double evmin = HUGE_VAL;             // г‚іг‚№гѓ€жњЂе°ЏеЂ¤гЂ‚е€ќжњџеЂ¤гЃЇе¤§гЃЌгЃЏ
+  double evthre = 0.000001;            // г‚іг‚№гѓ€е¤‰еЊ–й–ѕеЂ¤гЂ‚е¤‰еЊ–й‡ЏгЃЊгЃ“г‚Њд»Ґдё‹гЃЄг‚‰з№°г‚Љиї”гЃ—зµ‚дє†
+//  double evthre = 0.00000001;            // г‚іг‚№гѓ€е¤‰еЊ–й–ѕеЂ¤гЂ‚е¤‰еЊ–й‡ЏгЃЊгЃ“г‚Њд»Ґдё‹гЃЄг‚‰з№°г‚Љиї”гЃ—зµ‚дє†
   popt->setEvthre(evthre);
-  popt->setEvlimit(0.2);               // evlimit‚НЉO‚к’l‚Ми‡’l[m]
+  popt->setEvlimit(0.2);               // evlimitгЃЇе¤–г‚ЊеЂ¤гЃ®й–ѕеЂ¤[m]
 
-  double ev = 0;                       // ѓRѓXѓg
-  double evold = evmin;                // 1‚В‘O‚М’lЃBЋы‘©”»’и‚М‚Ѕ‚Я‚ЙЋg‚¤ЃB
+  double ev = 0;                       // г‚іг‚№гѓ€
+  double evold = evmin;                // 1гЃ¤е‰ЌгЃ®еЂ¤гЂ‚еЏЋжќџе€¤е®љгЃ®гЃџг‚ЃгЃ«дЅїгЃ†гЂ‚
   Pose2D pose = initPose;
   Pose2D poseMin = initPose;
-  for (int i=0; abs(evold-ev) > evthre && i<100; i++) {           // i<100‚НђU“®‘ОЌф
+  for (int i=0; abs(evold-ev) > evthre && i<100; i++) {           // i<100гЃЇжЊЇе‹•еЇѕз­–
     if (i > 0)
       evold = ev;
-    double mratio = dass->findCorrespondence(curScan, pose);      // ѓfЃ[ѓ^‘О‰ћ‚Г‚Ї
+    double mratio = dass->findCorrespondence(curScan, pose);      // гѓ‡гѓјг‚їеЇѕеїњгЃҐгЃ‘
     Pose2D newPose;
-    popt->setPoints(dass->curLps, dass->refLps);                  // ‘О‰ћЊ‹‰К‚р“n‚·
-    ev = popt->optimizePose(pose, newPose);                       // ‚»‚М‘О‰ћ‚Г‚Ї‚Й‚Ё‚ў‚ДѓЌѓ{ѓbѓg€К’u‚МЌЕ“K‰»
+    popt->setPoints(dass->curLps, dass->refLps);                  // еЇѕеїњзµђжћњг‚’жёЎгЃ™
+    ev = popt->optimizePose(pose, newPose);                       // гЃќгЃ®еЇѕеїњгЃҐгЃ‘гЃ«гЃЉгЃ„гЃ¦гѓ­гѓњгѓѓгѓ€дЅЌзЅ®гЃ®жњЂйЃ©еЊ–
     pose = newPose;
 
-    if (ev < evmin) {                                             // ѓRѓXѓgЌЕЏ¬Њ‹‰К‚р•Ы‘¶
+    if (ev < evmin) {                                             // г‚іг‚№гѓ€жњЂе°Џзµђжћњг‚’дїќе­
       poseMin = newPose;
       evmin = ev;
     }
@@ -58,15 +58,15 @@ double PoseEstimatorICP::estimatePose(Pose2D &initPose, Pose2D &estPose){
   estPose = poseMin;
 
   printf("finalError=%g, pnrate=%g\n", evmin, pnrate);
-  printf("estPose:  tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);      // Љm”F—p
+  printf("estPose:  tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);      // зўєиЄЌз”Ё
 
   double t1 = 1000*tim.elapsed();
-  printf("PoseEstimatorICP: t1=%g\n", t1);                 // Џ€—ќЋћЉФ
+  printf("PoseEstimatorICP: t1=%g\n", t1);                 // е‡¦зђ†ж™‚й–“
 
   if (evmin < HUGE_VAL)
-    totalError += evmin;                                   // ЊлЌ·Ќ‡Њv
-  totalTime += t1;                                         // Џ€—ќЋћЉФЌ‡Њv
-  printf("totalError=%g, totalTime=%g\n", totalError, totalTime);    // Љm”F—p
+    totalError += evmin;                                   // иЄ¤е·®еђ€иЁ€
+  totalTime += t1;                                         // е‡¦зђ†ж™‚й–“еђ€иЁ€
+  printf("totalError=%g, totalTime=%g\n", totalError, totalTime);    // зўєиЄЌз”Ё
 
   return(evmin);
 }

--- a/framework/PoseEstimatorICP.h
+++ b/framework/PoseEstimatorICP.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -28,16 +28,16 @@
 class PoseEstimatorICP
 {
 private:
-  const Scan2D *curScan;       // ���݃X�L����
-  size_t usedNum;              // ICP�Ɏg��ꂽ�_���BLoopDetector�ŐM�����`�F�b�N�Ɏg��
-  double pnrate;               // �������Ή��Â����ꂽ�_�̔䗦
+  const Scan2D *curScan;       // 現在スキャン
+  size_t usedNum;              // ICPに使われた点数。LoopDetectorで信頼性チェックに使う
+  double pnrate;               // 正しく対応づけされた点の比率
   
-  PoseOptimizer *popt;         // �œK���N���X
-  DataAssociator *dass;        // �f�[�^�Ή��Â��N���X
+  PoseOptimizer *popt;         // 最適化クラス
+  DataAssociator *dass;        // データ対応づけクラス
 
 public:
-  double totalError;           // �덷���v
-  double totalTime;            // �������ԍ��v
+  double totalError;           // 誤差合計
+  double totalTime;            // 処理時間合計
 
 public:
 
@@ -67,12 +67,12 @@ public:
   
   void setScanPair(const Scan2D *c, const Scan2D *r) {
     curScan = c;
-    dass->setRefBase(r->lps);           // �f�[�^�Ή��Â��̂��߂ɎQ�ƃX�L�����_��o�^
+    dass->setRefBase(r->lps);           // データ対応づけのために参照スキャン点を登録
   }
 
   void setScanPair(const Scan2D *c, const std::vector<LPoint2D> &refLps) {
     curScan = c;
-    dass->setRefBase(refLps);           // �f�[�^�Ή��Â��̂��߂ɎQ�ƃX�L�����_��o�^
+    dass->setRefBase(refLps);           // データ対応づけのために参照スキャン点を登録
   }
 
 ////////////

--- a/framework/PoseFuser.cpp
+++ b/framework/PoseFuser.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,33 +16,33 @@
 
 using namespace std;
 
-////////////// ’€ŽŸSLAM—p‚ÌƒZƒ“ƒT—Z‡ ////////////////
+////////////// é€æ¬¡SLAMç”¨ã®ã‚»ãƒ³ã‚µèžåˆ ////////////////
 
-// ’€ŽŸSLAM‚Å‚ÌICP‚ÆƒIƒhƒƒgƒŠ‚Ì„’èˆÚ“®—Ê‚ð—Z‡‚·‚éBdass‚ÉŽQÆƒXƒLƒƒƒ“‚ð“ü‚ê‚Ä‚¨‚­‚±‚ÆBcov‚ÉˆÚ“®—Ê‚Ì‹¤•ªŽUs—ñ‚ª“ü‚éB
+// é€æ¬¡SLAMã§ã®ICPã¨ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®æŽ¨å®šç§»å‹•é‡ã‚’èžåˆã™ã‚‹ã€‚dassã«å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã‚’å…¥ã‚Œã¦ãŠãã“ã¨ã€‚covã«ç§»å‹•é‡ã®å…±åˆ†æ•£è¡Œåˆ—ãŒå…¥ã‚‹ã€‚
 double PoseFuser::fusePose(Scan2D *curScan, const Pose2D &estPose, const Pose2D &odoMotion, const Pose2D &lastPose, Pose2D &fusedPose, Eigen::Matrix3d &fusedCov) {
-  // ICP‚Ì‹¤•ªŽU
-  dass->findCorrespondence(curScan, estPose);                                      // „’èˆÊ’uestPose‚ÅŒ»ÝƒXƒLƒƒƒ““_ŒQ‚ÆŽQÆƒXƒLƒƒƒ““_ŒQ‚Ì‘Î‰ž‚Ã‚¯
-  double ratio = cvc.calIcpCovariance(estPose, dass->curLps, dass->refLps, ecov);  // ‚±‚±‚Å“¾‚ç‚ê‚é‚Ì‚ÍA’n}À•WŒn‚Å‚ÌˆÊ’u‚Ì‹¤•ªŽU
+  // ICPã®å…±åˆ†æ•£
+  dass->findCorrespondence(curScan, estPose);                                      // æŽ¨å®šä½ç½®estPoseã§ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã¨å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã®å¯¾å¿œã¥ã‘
+  double ratio = cvc.calIcpCovariance(estPose, dass->curLps, dass->refLps, ecov);  // ã“ã“ã§å¾—ã‚‰ã‚Œã‚‹ã®ã¯ã€åœ°å›³åº§æ¨™ç³»ã§ã®ä½ç½®ã®å…±åˆ†æ•£
 
-  // ƒIƒhƒƒgƒŠ‚ÌˆÊ’u‚Æ‹¤•ªŽUB‘¬“x‰^“®ƒ‚ƒfƒ‹‚ðŽg‚¤‚ÆA’ZŠúŠÔ‚Å‚Í‹¤•ªŽU‚ª¬‚³‚·‚¬‚é‚½‚ßAŠÈˆÕ”Å‚Å‘å‚«‚ß‚ÉŒvŽZ‚·‚é
-  Pose2D predPose;                                                                 // —\‘ªˆÊ’u
-  Pose2D::calGlobalPose(odoMotion, lastPose, predPose);                            // ’¼‘OˆÊ’ulastPose‚ÉˆÚ“®—Ê‚ð‰Á‚¦‚Ä—\‘ªˆÊ’u‚ðŒvŽZ
+  // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®ä½ç½®ã¨å…±åˆ†æ•£ã€‚é€Ÿåº¦é‹å‹•ãƒ¢ãƒ‡ãƒ«ã‚’ä½¿ã†ã¨ã€çŸ­æœŸé–“ã§ã¯å…±åˆ†æ•£ãŒå°ã•ã™ãŽã‚‹ãŸã‚ã€ç°¡æ˜“ç‰ˆã§å¤§ãã‚ã«è¨ˆç®—ã™ã‚‹
+  Pose2D predPose;                                                                 // äºˆæ¸¬ä½ç½®
+  Pose2D::calGlobalPose(odoMotion, lastPose, predPose);                            // ç›´å‰ä½ç½®lastPoseã«ç§»å‹•é‡ã‚’åŠ ãˆã¦äºˆæ¸¬ä½ç½®ã‚’è¨ˆç®—
   Eigen::Matrix3d mcovL;
   double dT=0.1;
-  cvc.calMotionCovarianceSimple(odoMotion, dT, mcovL);                             // ƒIƒhƒƒgƒŠ‚Å“¾‚½ˆÚ“®—Ê‚Ì‹¤•ªŽUiŠÈˆÕ”Åj
-  CovarianceCalculator::rotateCovariance(estPose, mcovL, mcov);                    // Œ»ÝˆÊ’uestPose‚Å‰ñ“]‚³‚¹‚ÄA’n}À•WŒn‚Å‚Ì‹¤•ªŽUmcov‚ð“¾‚é
+  cvc.calMotionCovarianceSimple(odoMotion, dT, mcovL);                             // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã§å¾—ãŸç§»å‹•é‡ã®å…±åˆ†æ•£ï¼ˆç°¡æ˜“ç‰ˆï¼‰
+  CovarianceCalculator::rotateCovariance(estPose, mcovL, mcov);                    // ç¾åœ¨ä½ç½®estPoseã§å›žè»¢ã•ã›ã¦ã€åœ°å›³åº§æ¨™ç³»ã§ã®å…±åˆ†æ•£mcovã‚’å¾—ã‚‹
 
-  // ecov, mcov, cov‚Æ‚à‚ÉAlastPose‚ðŒ´“_‚Æ‚µ‚½‹ÇŠÀ•WŒn‚Å‚Ì’l
-  Eigen::Vector3d mu1(estPose.tx, estPose.ty, DEG2RAD(estPose.th));                // ICP‚É‚æ‚é„’è’l
-  Eigen::Vector3d mu2(predPose.tx, predPose.ty, DEG2RAD(predPose.th));             // ƒIƒhƒƒgƒŠ‚É‚æ‚é„’è’l
+  // ecov, mcov, covã¨ã‚‚ã«ã€lastPoseã‚’åŽŸç‚¹ã¨ã—ãŸå±€æ‰€åº§æ¨™ç³»ã§ã®å€¤
+  Eigen::Vector3d mu1(estPose.tx, estPose.ty, DEG2RAD(estPose.th));                // ICPã«ã‚ˆã‚‹æŽ¨å®šå€¤
+  Eigen::Vector3d mu2(predPose.tx, predPose.ty, DEG2RAD(predPose.th));             // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹æŽ¨å®šå€¤
   Eigen::Vector3d mu;
-  fuse(mu1, ecov, mu2, mcov, mu, fusedCov);                                        // 2‚Â‚Ì³‹K•ª•z‚Ì—Z‡
+  fuse(mu1, ecov, mu2, mcov, mu, fusedCov);                                        // 2ã¤ã®æ­£è¦åˆ†å¸ƒã®èžåˆ
 
-  fusedPose.setVal(mu[0], mu[1], RAD2DEG(mu[2]));                                  // —Z‡‚µ‚½ˆÚ“®—Ê‚ðŠi”[
+  fusedPose.setVal(mu[0], mu[1], RAD2DEG(mu[2]));                                  // èžåˆã—ãŸç§»å‹•é‡ã‚’æ ¼ç´
 
   totalCov = fusedCov;
 
-  // Šm”F—p
+  // ç¢ºèªç”¨
   printf("fusePose\n");
   double vals[2], vec1[2], vec2[2];
   printf("ecov: det=%g, ", ecov.determinant());
@@ -62,41 +62,41 @@ double PoseFuser::fusePose(Scan2D *curScan, const Pose2D &estPose, const Pose2D 
 void PoseFuser::calOdometryCovariance(const Pose2D &odoMotion, const Pose2D &lastPose, Eigen::Matrix3d &mcov) {
   Eigen::Matrix3d mcovL;
   double dT=0.1;
-  cvc.calMotionCovarianceSimple(odoMotion, dT, mcovL);                             // ƒIƒhƒƒgƒŠ‚Å“¾‚½ˆÚ“®—Ê‚Ì‹¤•ªŽUiŠÈˆÕ”Åj
-  CovarianceCalculator::rotateCovariance(lastPose, mcovL, mcov);                   // ’¼‘OˆÊ’ulastPose‚Å‰ñ“]‚³‚¹‚ÄAˆÊ’u‚Ì‹¤•ªŽUmcov‚ð“¾‚é
+  cvc.calMotionCovarianceSimple(odoMotion, dT, mcovL);                             // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã§å¾—ãŸç§»å‹•é‡ã®å…±åˆ†æ•£ï¼ˆç°¡æ˜“ç‰ˆï¼‰
+  CovarianceCalculator::rotateCovariance(lastPose, mcovL, mcov);                   // ç›´å‰ä½ç½®lastPoseã§å›žè»¢ã•ã›ã¦ã€ä½ç½®ã®å…±åˆ†æ•£mcovã‚’å¾—ã‚‹
 }
 
-/////// ƒKƒEƒX•ª•z‚Ì—Z‡ ///////
+/////// ã‚¬ã‚¦ã‚¹åˆ†å¸ƒã®èžåˆ ///////
 
-// 2‚Â‚Ì³‹K•ª•z‚ð—Z‡‚·‚éBmu‚Í•½‹ÏAcv‚Í‹¤•ªŽUB
+// 2ã¤ã®æ­£è¦åˆ†å¸ƒã‚’èžåˆã™ã‚‹ã€‚muã¯å¹³å‡ã€cvã¯å…±åˆ†æ•£ã€‚
 double PoseFuser::fuse(const Eigen::Vector3d &mu1, const Eigen::Matrix3d &cv1,  const Eigen::Vector3d &mu2, const Eigen::Matrix3d &cv2, Eigen::Vector3d &mu, Eigen::Matrix3d &cv) {
-  // ‹¤•ªŽUs—ñ‚Ì—Z‡
+  // å…±åˆ†æ•£è¡Œåˆ—ã®èžåˆ
   Eigen::Matrix3d IC1 = MyUtil::svdInverse(cv1);
   Eigen::Matrix3d IC2 = MyUtil::svdInverse(cv2);
   Eigen::Matrix3d IC = IC1 + IC2;
   cv = MyUtil::svdInverse(IC);
 
-  // Šp“x‚Ì•â³B—Z‡Žž‚É˜A‘±«‚ð•Û‚Â‚½‚ßB
-  Eigen::Vector3d mu11 = mu1;             // ICP‚Ì•ûŒü‚ðƒIƒhƒƒgƒŠ‚É‡‚¹‚é
+  // è§’åº¦ã®è£œæ­£ã€‚èžåˆæ™‚ã«é€£ç¶šæ€§ã‚’ä¿ã¤ãŸã‚ã€‚
+  Eigen::Vector3d mu11 = mu1;             // ICPã®æ–¹å‘ã‚’ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«åˆã›ã‚‹
   double da = mu2(2) - mu1(2);
   if (da > M_PI) 
     mu11(2) += 2*M_PI;
   else if (da < -M_PI)
     mu11(2) -= 2*M_PI;
 
-  // •½‹Ï‚Ì—Z‡
+  // å¹³å‡ã®èžåˆ
   Eigen::Vector3d nu1 = IC1*mu11;
   Eigen::Vector3d nu2 = IC2*mu2;
   Eigen::Vector3d nu3 = nu1 + nu2;
   mu = cv*nu3;
 
-  // Šp“x‚Ì•â³B(-pi, pi)‚ÉŽû‚ß‚é
+  // è§’åº¦ã®è£œæ­£ã€‚(-pi, pi)ã«åŽã‚ã‚‹
   if (mu(2) > M_PI) 
     mu(2) -= 2*M_PI;
   else if (mu(2) < -M_PI)
     mu(2) += 2*M_PI;
 
-  // ŒW”•”‚ÌŒvŽZ
+  // ä¿‚æ•°éƒ¨ã®è¨ˆç®—
   Eigen::Vector3d W1 = IC1*mu11;
   Eigen::Vector3d W2 = IC2*mu2;
   Eigen::Vector3d W = IC*mu;

--- a/framework/PoseFuser.h
+++ b/framework/PoseFuser.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -22,16 +22,16 @@
 #include "DataAssociator.h"
 #include "CovarianceCalculator.h"
 
-// ƒZƒ“ƒT—Z‡ŠíBICP‚ÆƒIƒhƒƒgƒŠ‚Ì„’è’l‚ð—Z‡‚·‚éB
+// ã‚»ãƒ³ã‚µèžåˆå™¨ã€‚ICPã¨ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®æŽ¨å®šå€¤ã‚’èžåˆã™ã‚‹ã€‚
 class PoseFuser
 {
 public:
-  Eigen::Matrix3d ecov;                      // ICP‚Ì‹¤•ªŽUs—ñ
-  Eigen::Matrix3d mcov;                      // ƒIƒhƒƒgƒŠ‚Ì‹¤•ªŽUs—ñ
+  Eigen::Matrix3d ecov;                      // ICPã®å…±åˆ†æ•£è¡Œåˆ—
+  Eigen::Matrix3d mcov;                      // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã®å…±åˆ†æ•£è¡Œåˆ—
   Eigen::Matrix3d totalCov;
   
-  DataAssociator *dass;                      // ƒf[ƒ^‘Î‰ž‚Ã‚¯Ší
-  CovarianceCalculator cvc;                 // ‹¤•ªŽUŒvŽZŠí
+  DataAssociator *dass;                      // ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘å™¨
+  CovarianceCalculator cvc;                 // å…±åˆ†æ•£è¨ˆç®—å™¨
 
 public:
   PoseFuser() {
@@ -54,11 +54,11 @@ public:
     dass->setRefBase(refLps);
   }
 
-  // ICP‚Ì‹¤•ªŽUs—ñ‚ÌŒvŽZBsetRefLps‚ÌŒã‚És‚¤‚±‚ÆB
+  // ICPã®å…±åˆ†æ•£è¡Œåˆ—ã®è¨ˆç®—ã€‚setRefLpsã®å¾Œã«è¡Œã†ã“ã¨ã€‚
   double calIcpCovariance(const Pose2D &estMotion, const Scan2D *curScan, Eigen::Matrix3d &cov) {
     dass->findCorrespondence(curScan, estMotion);
 
-    // ICP‚Ì‹¤•ªŽUB‚±‚±‚Å“¾‚ç‚ê‚é‚Ì‚ÍA¢ŠEÀ•WŒn‚Å‚Ì‹¤•ªŽU
+    // ICPã®å…±åˆ†æ•£ã€‚ã“ã“ã§å¾—ã‚‰ã‚Œã‚‹ã®ã¯ã€ä¸–ç•Œåº§æ¨™ç³»ã§ã®å…±åˆ†æ•£
     double ratio = cvc.calIcpCovariance(estMotion, dass->curLps, dass->refLps, cov);
     return(ratio);
   }

--- a/framework/PoseGraph.cpp
+++ b/framework/PoseGraph.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,28 +16,28 @@
 
 using namespace std;
 
-//////////// ƒOƒ‰ƒt¶¬ ////////////
+//////////// ã‚°ãƒ©ãƒ•ç”Ÿæˆ ////////////
 
-// ƒ|[ƒYƒOƒ‰ƒt‚Éƒm[ƒh’Ç‰Á
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã«ãƒãƒ¼ãƒ‰è¿½åŠ 
 PoseNode *PoseGraph::addNode(const Pose2D &pose) {
-  PoseNode *n1 = allocNode();                // ƒm[ƒh¶¬
-  addNode(n1, pose);                         // ƒ|[ƒYƒOƒ‰ƒt‚Éƒm[ƒh’Ç‰Á
+  PoseNode *n1 = allocNode();                // ãƒãƒ¼ãƒ‰ç”Ÿæˆ
+  addNode(n1, pose);                         // ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã«ãƒãƒ¼ãƒ‰è¿½åŠ 
 
   return(n1);
 }
 
-// ƒ|[ƒYƒOƒ‰ƒt‚Éƒm[ƒh’Ç‰Á
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã«ãƒãƒ¼ãƒ‰è¿½åŠ 
 void PoseGraph::addNode(PoseNode *n1, const Pose2D &pose) {
-  n1->setNid((int)nodes.size());             // ƒm[ƒhID•t—^Bƒm[ƒh‚Ì’Ê‚µ”Ô†‚Æ“¯‚¶
-  n1->setPose(pose);                         // ƒƒ{ƒbƒgˆÊ’u‚ğİ’è
-  nodes.push_back(n1);                       // nodes‚ÌÅŒã‚É’Ç‰Á
+  n1->setNid((int)nodes.size());             // ãƒãƒ¼ãƒ‰IDä»˜ä¸ã€‚ãƒãƒ¼ãƒ‰ã®é€šã—ç•ªå·ã¨åŒã˜
+  n1->setPose(pose);                         // ãƒ­ãƒœãƒƒãƒˆä½ç½®ã‚’è¨­å®š
+  nodes.push_back(n1);                       // nodesã®æœ€å¾Œã«è¿½åŠ 
 }
 
-// ƒm[ƒhID(nid)‚©‚çƒm[ƒhÀ‘Ì‚ğŒ©‚Â‚¯‚é
+// ãƒãƒ¼ãƒ‰ID(nid)ã‹ã‚‰ãƒãƒ¼ãƒ‰å®Ÿä½“ã‚’è¦‹ã¤ã‘ã‚‹
 PoseNode *PoseGraph::findNode(int nid) {
-  for (size_t i=0; i<nodes.size(); i++) {    // ’Pƒ‚ÉüŒ`’Tõ
+  for (size_t i=0; i<nodes.size(); i++) {    // å˜ç´”ã«ç·šå½¢æ¢ç´¢
     PoseNode *n = nodes[i];
-    if (n->nid == nid)                       // nid‚ªˆê’v‚µ‚½‚çŒ©‚Â‚¯‚½
+    if (n->nid == nid)                       // nidãŒä¸€è‡´ã—ãŸã‚‰è¦‹ã¤ã‘ãŸ
       return(n);
   }
 
@@ -46,28 +46,28 @@ PoseNode *PoseGraph::findNode(int nid) {
 
 //////////
 
-// ƒ|[ƒYƒOƒ‰ƒt‚ÉƒA[ƒN‚ğ’Ç‰Á‚·‚é
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã«ã‚¢ãƒ¼ã‚¯ã‚’è¿½åŠ ã™ã‚‹
 void PoseGraph::addArc(PoseArc *arc) {
-  arc->src->addArc(arc);                   // n“_ƒm[ƒh‚Éarc‚ğ’Ç‰Á
-  arc->dst->addArc(arc);                   // I“_ƒm[ƒh‚Éarc‚ğ’Ç‰Á
-  arcs.push_back(arc);                     // arcs‚ÌÅŒã‚Éarc‚ğ’Ç‰Á
+  arc->src->addArc(arc);                   // å§‹ç‚¹ãƒãƒ¼ãƒ‰ã«arcã‚’è¿½åŠ 
+  arc->dst->addArc(arc);                   // çµ‚ç‚¹ãƒãƒ¼ãƒ‰ã«arcã‚’è¿½åŠ 
+  arcs.push_back(arc);                     // arcsã®æœ€å¾Œã«arcã‚’è¿½åŠ 
 }
 
-// n“_ƒm[ƒhsrcNid‚ÆI“_ƒm[ƒhdstNid‚ÌŠÔ‚ÉƒA[ƒN‚ğ¶¬‚·‚é
+// å§‹ç‚¹ãƒãƒ¼ãƒ‰srcNidã¨çµ‚ç‚¹ãƒãƒ¼ãƒ‰dstNidã®é–“ã«ã‚¢ãƒ¼ã‚¯ã‚’ç”Ÿæˆã™ã‚‹
 PoseArc *PoseGraph::makeArc(int srcNid, int dstNid, const Pose2D &relPose, const Eigen::Matrix3d &cov) {
-//  Eigen::Matrix3d inf = cov.inverse();         // inf‚Ícov‚Ì‹ts—ñ
-  Eigen::Matrix3d inf = MyUtil::svdInverse(cov);            // inf‚Ícov‚Ì‹ts—ñ
+//  Eigen::Matrix3d inf = cov.inverse();         // infã¯covã®é€†è¡Œåˆ—
+  Eigen::Matrix3d inf = MyUtil::svdInverse(cov);            // infã¯covã®é€†è¡Œåˆ—
 
-  PoseNode *src = nodes[srcNid];                // n“_ƒm[ƒh
-  PoseNode *dst = nodes[dstNid];                // I“_ƒm[ƒh
+  PoseNode *src = nodes[srcNid];                // å§‹ç‚¹ãƒãƒ¼ãƒ‰
+  PoseNode *dst = nodes[dstNid];                // çµ‚ç‚¹ãƒãƒ¼ãƒ‰
 
-  PoseArc *arc = allocArc();                    // ƒA[ƒN‚Ì¶¬
-  arc->setup(src, dst, relPose, inf);      // relPose‚ÍŒv‘ª‚É‚æ‚é‘Š‘ÎˆÊ’u
+  PoseArc *arc = allocArc();                    // ã‚¢ãƒ¼ã‚¯ã®ç”Ÿæˆ
+  arc->setup(src, dst, relPose, inf);      // relPoseã¯è¨ˆæ¸¬ã«ã‚ˆã‚‹ç›¸å¯¾ä½ç½®
 
   return(arc);
 }
 
-// n“_ƒm[ƒh‚ªsrcNidAI“_ƒm[ƒh‚ªdstNid‚Å‚ ‚éƒA[ƒN‚ğ•Ô‚·
+// å§‹ç‚¹ãƒãƒ¼ãƒ‰ãŒsrcNidã€çµ‚ç‚¹ãƒãƒ¼ãƒ‰ãŒdstNidã§ã‚ã‚‹ã‚¢ãƒ¼ã‚¯ã‚’è¿”ã™
 PoseArc *PoseGraph::findArc(int srcNid, int dstNid) {
   for (size_t i=0; i<arcs.size(); i++) {
     PoseArc *a = arcs[i];
@@ -79,7 +79,7 @@ PoseArc *PoseGraph::findArc(int srcNid, int dstNid) {
 
 ////////////////
 
-// Šm”F—p
+// ç¢ºèªç”¨
 void PoseGraph::printNodes() {
   printf("--- printNodes ---\n");
   printf("nodes.size=%lu\n", nodes.size());
@@ -94,7 +94,7 @@ void PoseGraph::printNodes() {
   }
 }
 
-// Šm”F—p
+// ç¢ºèªç”¨
 void PoseGraph::printArcs() {
   printf("--- printArcs ---\n");
   printf("arcs.size=%lu\n", arcs.size());

--- a/framework/PoseGraph.h
+++ b/framework/PoseGraph.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -23,12 +23,12 @@ struct PoseArc;
 
 /////////
 
-// ƒ|[ƒYƒOƒ‰ƒt‚Ì’¸“_
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã®é ‚ç‚¹
 struct PoseNode
 {
-  int nid;                       // ƒm[ƒhIDBPoseGraph‚Ìnodes‚ÌƒCƒ“ƒfƒbƒNƒXi’Ê‚µ”Ô†j
-  Pose2D pose;                   // ‚±‚Ìƒm[ƒh‚Ìƒƒ{ƒbƒgˆÊ’u
-  std::vector<PoseArc*> arcs;    // ‚±‚Ìƒm[ƒh‚É‚Â‚È‚ª‚éƒA[ƒN
+  int nid;                       // ãƒãƒ¼ãƒ‰IDã€‚PoseGraphã®nodesã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹ï¼ˆé€šã—ç•ªå·ï¼‰
+  Pose2D pose;                   // ã“ã®ãƒãƒ¼ãƒ‰ã®ãƒ­ãƒœãƒƒãƒˆä½ç½®
+  std::vector<PoseArc*> arcs;    // ã“ã®ãƒãƒ¼ãƒ‰ã«ã¤ãªãŒã‚‹ã‚¢ãƒ¼ã‚¯
 
   PoseNode(): nid(-1) {
   }
@@ -63,13 +63,13 @@ struct PoseNode
 
 ////////
 
-// ƒ|[ƒYƒOƒ‰ƒt‚Ì•Ó
+// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•ã®è¾º
 struct PoseArc
 {
-  PoseNode *src;                      // ‚±‚ÌƒA[ƒN‚Ìn“_‘¤‚Ìƒm[ƒh
-  PoseNode *dst;                      // ‚±‚ÌƒA[ƒN‚ÌI“_‘¤‚Ìƒm[ƒh
-  Pose2D relPose;                     // ‚±‚ÌƒA[ƒN‚Ì‚à‚Â‘Š‘ÎˆÊ’u(Œv‘ª’l)
-  Eigen::Matrix3d inf;                // î•ñs—ñ
+  PoseNode *src;                      // ã“ã®ã‚¢ãƒ¼ã‚¯ã®å§‹ç‚¹å´ã®ãƒãƒ¼ãƒ‰
+  PoseNode *dst;                      // ã“ã®ã‚¢ãƒ¼ã‚¯ã®çµ‚ç‚¹å´ã®ãƒãƒ¼ãƒ‰
+  Pose2D relPose;                     // ã“ã®ã‚¢ãƒ¼ã‚¯ã®ã‚‚ã¤ç›¸å¯¾ä½ç½®(è¨ˆæ¸¬å€¤)
+  Eigen::Matrix3d inf;                // æƒ…å ±è¡Œåˆ—
 
   PoseArc(void) : src(nullptr), dst(nullptr){
   }
@@ -92,21 +92,21 @@ struct PoseArc
 
 };
 
-////////// ƒ|[ƒYƒOƒ‰ƒt //////////
+////////// ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ• //////////
 
 class PoseGraph
 {
 private:
   static const int POOL_SIZE=100000;
-  std::vector<PoseNode> nodePool;     // ƒm[ƒh¶¬—p‚Ìƒƒ‚ƒŠƒv[ƒ‹
-  std::vector<PoseArc> arcPool;       // ƒA[ƒN¶¬—p‚Ìƒƒ‚ƒŠƒv[ƒ‹
+  std::vector<PoseNode> nodePool;     // ãƒãƒ¼ãƒ‰ç”Ÿæˆç”¨ã®ãƒ¡ãƒ¢ãƒªãƒ—ãƒ¼ãƒ«
+  std::vector<PoseArc> arcPool;       // ã‚¢ãƒ¼ã‚¯ç”Ÿæˆç”¨ã®ãƒ¡ãƒ¢ãƒªãƒ—ãƒ¼ãƒ«
 
 public:
-  std::vector<PoseNode*> nodes;       // ƒm[ƒh‚ÌW‡
-  std::vector<PoseArc*> arcs;         // ƒA[ƒN‚ÌW‡BƒA[ƒN‚Í•Ğ•ûŒü‚Ì‚İ‚à‚Â
+  std::vector<PoseNode*> nodes;       // ãƒãƒ¼ãƒ‰ã®é›†åˆ
+  std::vector<PoseArc*> arcs;         // ã‚¢ãƒ¼ã‚¯ã®é›†åˆã€‚ã‚¢ãƒ¼ã‚¯ã¯ç‰‡æ–¹å‘ã®ã¿ã‚‚ã¤
 
   PoseGraph() {
-    nodePool.reserve(POOL_SIZE);      // ƒƒ‚ƒŠƒv[ƒ‹‚Ì—Ìˆæ‚ğÅ‰‚ÉŠm•ÛBvector‚ÍƒTƒCƒY‚ª•Ï‚í‚é‚Æ’†g‚ªˆÚ“®‚·‚é‚Ì‚Å‚±‚¤‚µ‚È‚¢‚ÆŠëŒ¯
+    nodePool.reserve(POOL_SIZE);      // ãƒ¡ãƒ¢ãƒªãƒ—ãƒ¼ãƒ«ã®é ˜åŸŸã‚’æœ€åˆã«ç¢ºä¿ã€‚vectorã¯ã‚µã‚¤ã‚ºãŒå¤‰ã‚ã‚‹ã¨ä¸­èº«ãŒç§»å‹•ã™ã‚‹ã®ã§ã“ã†ã—ãªã„ã¨å±é™º
     arcPool.reserve(POOL_SIZE);
   }
 
@@ -122,7 +122,7 @@ public:
     arcPool.clear();
   }
 
-  // ƒm[ƒh‚Ì¶¬
+  // ãƒãƒ¼ãƒ‰ã®ç”Ÿæˆ
   PoseNode *allocNode() {
     if (nodePool.size() >= POOL_SIZE) {
       printf("Error: exceeds nodePool capacity\n");
@@ -130,11 +130,11 @@ public:
     }
    
     PoseNode node;
-    nodePool.emplace_back(node);      // ƒƒ‚ƒŠƒv[ƒ‹‚É’Ç‰Á‚µ‚ÄA‚»‚ê‚ğQÆ‚·‚éB
+    nodePool.emplace_back(node);      // ãƒ¡ãƒ¢ãƒªãƒ—ãƒ¼ãƒ«ã«è¿½åŠ ã—ã¦ã€ãã‚Œã‚’å‚ç…§ã™ã‚‹ã€‚
     return(&(nodePool.back()));
   }
 
-  // ƒA[ƒN‚Ì¶¬
+  // ã‚¢ãƒ¼ã‚¯ã®ç”Ÿæˆ
   PoseArc *allocArc() {
     if (arcPool.size() >= POOL_SIZE) {
       printf("Error: exceeds arcPool capacity\n");
@@ -142,7 +142,7 @@ public:
     }
 
     PoseArc arc;
-    arcPool.emplace_back(arc);       // ƒƒ‚ƒŠƒv[ƒ‹‚É’Ç‰Á‚µ‚ÄA‚»‚ê‚ğQÆ‚·‚éB
+    arcPool.emplace_back(arc);       // ãƒ¡ãƒ¢ãƒªãƒ—ãƒ¼ãƒ«ã«è¿½åŠ ã—ã¦ã€ãã‚Œã‚’å‚ç…§ã™ã‚‹ã€‚
     return(&(arcPool.back()));
   }
 

--- a/framework/PoseOptimizer.h
+++ b/framework/PoseOptimizer.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,15 +24,15 @@
 class PoseOptimizer
 {
 public:
-  int allN;             // ŒJ‚è•Ô‚µ‘”BƒeƒXƒg—p
-  double sum;           // c·‡ŒvBƒeƒXƒg—p
+  int allN;             // ç¹°ã‚Šè¿”ã—ç·æ•°ã€‚ãƒ†ã‚¹ãƒˆç”¨
+  double sum;           // æ®‹å·®åˆè¨ˆã€‚ãƒ†ã‚¹ãƒˆç”¨
 
 protected:
-  double evthre;                // ƒRƒXƒg•Ï‰»è‡’lB•Ï‰»—Ê‚ª‚±‚êˆÈ‰º‚È‚çŒJ‚è•Ô‚µI—¹
-  double dd;                    // ”’l”÷•ª‚Ì‚İi•Àij
-  double da;                    // ”’l”÷•ª‚Ì‚İi‰ñ“]j
+  double evthre;                // ã‚³ã‚¹ãƒˆå¤‰åŒ–é–¾å€¤ã€‚å¤‰åŒ–é‡ãŒã“ã‚Œä»¥ä¸‹ãªã‚‰ç¹°ã‚Šè¿”ã—çµ‚äº†
+  double dd;                    // æ•°å€¤å¾®åˆ†ã®åˆ»ã¿ï¼ˆä¸¦é€²ï¼‰
+  double da;                    // æ•°å€¤å¾®åˆ†ã®åˆ»ã¿ï¼ˆå›è»¢ï¼‰
 
-  CostFunction *cfunc;          // ƒRƒXƒgŠÖ”
+  CostFunction *cfunc;          // ã‚³ã‚¹ãƒˆé–¢æ•°
 
 public:
   PoseOptimizer(): evthre(0.000001), dd(0.00001), da(0.00001), cfunc(nullptr) {

--- a/framework/RefScanMaker.h
+++ b/framework/RefScanMaker.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -25,8 +25,8 @@
 class RefScanMaker
 {
 protected:
-  const PointCloudMap *pcmap;           // “_ŒQ’n}
-  Scan2D refScan;                       // QÆƒXƒLƒƒƒ“–{‘ÌB‚±‚ê‚ğŠO‚É’ñ‹Ÿ
+  const PointCloudMap *pcmap;           // ç‚¹ç¾¤åœ°å›³
+  Scan2D refScan;                       // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³æœ¬ä½“ã€‚ã“ã‚Œã‚’å¤–ã«æä¾›
 
 public:
   RefScanMaker() : pcmap(nullptr) {

--- a/framework/Scan2D.cpp
+++ b/framework/Scan2D.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),

--- a/framework/Scan2D.h
+++ b/framework/Scan2D.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -22,15 +22,15 @@
 
 //////////
 
-// ƒXƒLƒƒƒ“
+// ã‚¹ã‚­ãƒ£ãƒ³
 struct Scan2D
 {
-  static double MAX_SCAN_RANGE;              // ƒXƒLƒƒƒ““_‚Ì‹——£’lãŒÀ[m]
-  static double MIN_SCAN_RANGE;              // ƒXƒLƒƒƒ““_‚Ì‹——£’l‰ºŒÀ[m]
+  static double MAX_SCAN_RANGE;              // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®è·é›¢å€¤ä¸Šé™[m]
+  static double MIN_SCAN_RANGE;              // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®è·é›¢å€¤ä¸‹é™[m]
 
-  int sid;                                   // ƒXƒLƒƒƒ“id
-  Pose2D pose;                               // ƒXƒLƒƒƒ“æ“¾‚ÌƒIƒhƒƒgƒŠ’l
-  std::vector<LPoint2D> lps;                 // ƒXƒLƒƒƒ““_ŒQ
+  int sid;                                   // ã‚¹ã‚­ãƒ£ãƒ³id
+  Pose2D pose;                               // ã‚¹ã‚­ãƒ£ãƒ³å–å¾—æ™‚ã®ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå€¤
+  std::vector<LPoint2D> lps;                 // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
 
   Scan2D() : sid(0) {
   }

--- a/framework/ScanMatcher2D.cpp
+++ b/framework/ScanMatcher2D.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,71 +18,71 @@ using namespace std;
 
 /////////
 
-// ƒXƒLƒƒƒ“ƒ}ƒbƒ`ƒ“ƒO‚ÌÀs
+// ã‚¹ã‚­ãƒ£ãƒ³ãƒãƒƒãƒãƒ³ã‚°ã®å®Ÿè¡Œ
 bool ScanMatcher2D::matchScan(Scan2D &curScan) {
   ++cnt;
 
   printf("----- ScanMatcher2D: cnt=%d start -----\n", cnt);
 
-  // spres‚ªİ’è‚³‚ê‚Ä‚¢‚ê‚ÎAƒXƒLƒƒƒ““_ŠÔŠu‚ğ‹Ïˆê‰»‚·‚é
+  // spresãŒè¨­å®šã•ã‚Œã¦ã„ã‚Œã°ã€ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”ã‚’å‡ä¸€åŒ–ã™ã‚‹
   if (spres != nullptr)
     spres->resamplePoints(&curScan);
 
-  // spana‚ªİ’è‚³‚ê‚Ä‚¢‚ê‚ÎAƒXƒLƒƒƒ““_‚Ì–@ü‚ğŒvZ‚·‚é
+  // spanaãŒè¨­å®šã•ã‚Œã¦ã„ã‚Œã°ã€ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ³•ç·šã‚’è¨ˆç®—ã™ã‚‹
   if (spana != nullptr)
     spana->analysePoints(curScan.lps);
 
-  // Å‰‚ÌƒXƒLƒƒƒ“‚Í’P‚É’n}‚É“ü‚ê‚é‚¾‚¯
+  // æœ€åˆã®ã‚¹ã‚­ãƒ£ãƒ³ã¯å˜ã«åœ°å›³ã«å…¥ã‚Œã‚‹ã ã‘
   if (cnt == 0) {
     growMap(curScan, initPose);
-    prevScan = curScan;                      // ’¼‘OƒXƒLƒƒƒ“‚Ìİ’è
+    prevScan = curScan;                      // ç›´å‰ã‚¹ã‚­ãƒ£ãƒ³ã®è¨­å®š
     return(true);
   }
 
-  // Scan‚É“ü‚Á‚Ä‚¢‚éƒIƒhƒƒgƒŠ’l‚ğ—p‚¢‚ÄˆÚ“®—Ê‚ğŒvZ‚·‚é
-  Pose2D odoMotion;                                                   // ƒIƒhƒƒgƒŠ‚ÉŠî‚Ã‚­ˆÚ“®—Ê
-  Pose2D::calRelativePose(curScan.pose, prevScan.pose, odoMotion);    // ‘OƒXƒLƒƒƒ“‚Æ‚Ì‘Š‘ÎˆÊ’u‚ªˆÚ“®—Ê
+  // Scanã«å…¥ã£ã¦ã„ã‚‹ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå€¤ã‚’ç”¨ã„ã¦ç§»å‹•é‡ã‚’è¨ˆç®—ã™ã‚‹
+  Pose2D odoMotion;                                                   // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«åŸºã¥ãç§»å‹•é‡
+  Pose2D::calRelativePose(curScan.pose, prevScan.pose, odoMotion);    // å‰ã‚¹ã‚­ãƒ£ãƒ³ã¨ã®ç›¸å¯¾ä½ç½®ãŒç§»å‹•é‡
 
-  Pose2D lastPose = pcmap->getLastPose();                        // ’¼‘OˆÊ’u
-  Pose2D predPose;                                               // ƒIƒhƒƒgƒŠ‚É‚æ‚é—\‘ªˆÊ’u
-  Pose2D::calGlobalPose(odoMotion, lastPose, predPose);          // ’¼‘OˆÊ’u‚ÉˆÚ“®—Ê‚ğ‰Á‚¦‚Ä—\‘ªˆÊ’u‚ğ“¾‚é
+  Pose2D lastPose = pcmap->getLastPose();                        // ç›´å‰ä½ç½®
+  Pose2D predPose;                                               // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹äºˆæ¸¬ä½ç½®
+  Pose2D::calGlobalPose(odoMotion, lastPose, predPose);          // ç›´å‰ä½ç½®ã«ç§»å‹•é‡ã‚’åŠ ãˆã¦äºˆæ¸¬ä½ç½®ã‚’å¾—ã‚‹
 
-  const Scan2D *refScan = rsm->makeRefScan();                    // QÆƒXƒLƒƒƒ“‚Ì¶¬
-  estim->setScanPair(&curScan, refScan);                         // ICP‚ÉƒXƒLƒƒƒ“‚ğİ’è
+  const Scan2D *refScan = rsm->makeRefScan();                    // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç”Ÿæˆ
+  estim->setScanPair(&curScan, refScan);                         // ICPã«ã‚¹ã‚­ãƒ£ãƒ³ã‚’è¨­å®š
   printf("curScan.size=%lu, refScan.size=%lu\n", curScan.lps.size(), refScan->lps.size());
 
-  Pose2D estPose;                                                // ICP‚É‚æ‚é„’èˆÊ’u
-  double score = estim->estimatePose(predPose, estPose);         // —\‘ªˆÊ’u‚ğ‰Šú’l‚É‚µ‚ÄICP‚ğÀs
+  Pose2D estPose;                                                // ICPã«ã‚ˆã‚‹æ¨å®šä½ç½®
+  double score = estim->estimatePose(predPose, estPose);         // äºˆæ¸¬ä½ç½®ã‚’åˆæœŸå€¤ã«ã—ã¦ICPã‚’å®Ÿè¡Œ
   size_t usedNum = estim->getUsedNum();
 
-  bool successful;                                               // ƒXƒLƒƒƒ“ƒ}ƒbƒ`ƒ“ƒO‚É¬Œ÷‚µ‚½‚©‚Ç‚¤‚©
-  if (score <= scthre && usedNum >= nthre)                       // ƒXƒRƒA‚ªè‡’l‚æ‚è¬‚³‚¯‚ê‚Î¬Œ÷‚Æ‚·‚é
+  bool successful;                                               // ã‚¹ã‚­ãƒ£ãƒ³ãƒãƒƒãƒãƒ³ã‚°ã«æˆåŠŸã—ãŸã‹ã©ã†ã‹
+  if (score <= scthre && usedNum >= nthre)                       // ã‚¹ã‚³ã‚¢ãŒé–¾å€¤ã‚ˆã‚Šå°ã•ã‘ã‚Œã°æˆåŠŸã¨ã™ã‚‹
     successful = true;
   else 
     successful = false;
   printf("score=%g, usedNum=%lu, successful=%d\n", score, usedNum, successful);
 
-  if (dgcheck) {                         // ‘Ş‰»‚Ì‘Îˆ‚ğ‚·‚éê‡
+  if (dgcheck) {                         // é€€åŒ–ã®å¯¾å‡¦ã‚’ã™ã‚‹å ´åˆ
     if (successful) {
-      Pose2D fusedPose;                       // —Z‡Œ‹‰Ê
-      Eigen::Matrix3d fusedCov;               // ƒZƒ“ƒT—Z‡Œã‚Ì‹¤•ªU
+      Pose2D fusedPose;                       // èåˆçµæœ
+      Eigen::Matrix3d fusedCov;               // ã‚»ãƒ³ã‚µèåˆå¾Œã®å…±åˆ†æ•£
       pfu->setRefScan(refScan);
-      // ƒZƒ“ƒT—Z‡Šípfu‚ÅAICPŒ‹‰Ê‚ÆƒIƒhƒƒgƒŠ’l‚ğ—Z‡‚·‚é
+      // ã‚»ãƒ³ã‚µèåˆå™¨pfuã§ã€ICPçµæœã¨ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå€¤ã‚’èåˆã™ã‚‹
       double ratio = pfu->fusePose(&curScan, estPose, odoMotion, lastPose, fusedPose, fusedCov);
       estPose = fusedPose;
       cov = fusedCov;
-      printf("ratio=%g. Pose fused.\n", ratio);     // ratio‚Í‘Ş‰»“xBŠm”F—p
+      printf("ratio=%g. Pose fused.\n", ratio);     // ratioã¯é€€åŒ–åº¦ã€‚ç¢ºèªç”¨
 
-      // ‹¤•ªU‚ğ—İÏ‚·‚é
-      Eigen::Matrix3d covL;               // ˆÚ“®—Ê‚Ì‹¤•ªU
-      CovarianceCalculator::rotateCovariance(lastPose, fusedCov, covL, true);          // ˆÚ“®—Ê‚Ì‹¤•ªU‚É•ÏŠ·
-      Eigen::Matrix3d tcov;                // —İÏŒã‚Ì‹¤•ªU
+      // å…±åˆ†æ•£ã‚’ç´¯ç©ã™ã‚‹
+      Eigen::Matrix3d covL;               // ç§»å‹•é‡ã®å…±åˆ†æ•£
+      CovarianceCalculator::rotateCovariance(lastPose, fusedCov, covL, true);          // ç§»å‹•é‡ã®å…±åˆ†æ•£ã«å¤‰æ›
+      Eigen::Matrix3d tcov;                // ç´¯ç©å¾Œã®å…±åˆ†æ•£
       CovarianceCalculator::accumulateCovariance(lastPose, estPose, totalCov, covL, tcov);
       totalCov = tcov;
     }
-    else {                                   // ICP¬Œ÷‚Å‚È‚¯‚ê‚ÎAƒIƒhƒƒgƒŠ‚É‚æ‚é—\‘ªˆÊ’u‚ğg‚¤
+    else {                                   // ICPæˆåŠŸã§ãªã‘ã‚Œã°ã€ã‚ªãƒ‰ãƒ¡ãƒˆãƒªã«ã‚ˆã‚‹äºˆæ¸¬ä½ç½®ã‚’ä½¿ã†
       estPose = predPose;
-      pfu->calOdometryCovariance(odoMotion, lastPose, cov);       // cov‚ÍƒIƒhƒƒgƒŠ‹¤•ªU‚¾‚¯
+      pfu->calOdometryCovariance(odoMotion, lastPose, cov);       // covã¯ã‚ªãƒ‰ãƒ¡ãƒˆãƒªå…±åˆ†æ•£ã ã‘
     }
   }
   else {
@@ -90,26 +90,26 @@ bool ScanMatcher2D::matchScan(Scan2D &curScan) {
       estPose = predPose;
   }
 
-  growMap(curScan, estPose);               // ’n}‚ÉƒXƒLƒƒƒ““_ŒQ‚ğ’Ç‰Á
-  prevScan = curScan;                      // ’¼‘OƒXƒLƒƒƒ“‚Ìİ’è
+  growMap(curScan, estPose);               // åœ°å›³ã«ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’è¿½åŠ 
+  prevScan = curScan;                      // ç›´å‰ã‚¹ã‚­ãƒ£ãƒ³ã®è¨­å®š
 
-  // Šm”F—p
+  // ç¢ºèªç”¨
 //  printf("lastPose: tx=%g, ty=%g, th=%g\n", lastPose.tx, lastPose.ty, lastPose.th);
-  printf("predPose: tx=%g, ty=%g, th=%g\n", predPose.tx, predPose.ty, predPose.th);     // Šm”F—p
+  printf("predPose: tx=%g, ty=%g, th=%g\n", predPose.tx, predPose.ty, predPose.th);     // ç¢ºèªç”¨
   printf("estPose: tx=%g, ty=%g, th=%g\n", estPose.tx, estPose.ty, estPose.th);
   printf("cov: %g, %g, %g, %g\n", totalCov(0,0), totalCov(0,1), totalCov(1,0), totalCov(1,1));
   printf("mcov: %g, %g, %g, %g\n", pfu->mcov(0,0), pfu->mcov(0,1), pfu->mcov(1,0), pfu->mcov(1,1));
   printf("ecov: %g, %g, %g, %g\n", pfu->ecov(0,0), pfu->ecov(0,1), pfu->ecov(1,0), pfu->ecov(1,1));
 
-  // ‹¤•ªU‚Ì•Û‘¶iŠm”F—pj
+  // å…±åˆ†æ•£ã®ä¿å­˜ï¼ˆç¢ºèªç”¨ï¼‰
 //  PoseCov pcov(estPose, cov);
 //  PoseCov pcov(estPose, totalCov);
 //  PoseCov pcov(estPose, pfu->mcov);
   PoseCov pcov(estPose, pfu->ecov);
   poseCovs.emplace_back(pcov);
 
-  // —İÏ‘–s‹——£‚ÌŒvZiŠm”F—pj
-  Pose2D estMotion;                                                    // „’èˆÚ“®—Ê
+  // ç´¯ç©èµ°è¡Œè·é›¢ã®è¨ˆç®—ï¼ˆç¢ºèªç”¨ï¼‰
+  Pose2D estMotion;                                                    // æ¨å®šç§»å‹•é‡
   Pose2D::calRelativePose(estPose, lastPose, estMotion);
   atd += sqrt(estMotion.tx*estMotion.tx + estMotion.ty*estMotion.ty); 
   printf("atd=%g\n", atd);
@@ -119,35 +119,35 @@ bool ScanMatcher2D::matchScan(Scan2D &curScan) {
 
 ////////////////////
 
-// Œ»İƒXƒLƒƒƒ“‚ğ’Ç‰Á‚µ‚ÄA’n}‚ğ¬’·‚³‚¹‚é
+// ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã‚’è¿½åŠ ã—ã¦ã€åœ°å›³ã‚’æˆé•·ã•ã›ã‚‹
 void ScanMatcher2D::growMap(const Scan2D &scan, const Pose2D &pose) {
-  const vector<LPoint2D> &lps = scan.lps;                // ƒXƒLƒƒƒ““_ŒQ(ƒƒ{ƒbƒgÀ•WŒn)
-  const double (*R)[2] = pose.Rmat;                      // „’è‚µ‚½ƒƒ{ƒbƒgˆÊ’u
+  const vector<LPoint2D> &lps = scan.lps;                // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤(ãƒ­ãƒœãƒƒãƒˆåº§æ¨™ç³»)
+  const double (*R)[2] = pose.Rmat;                      // æ¨å®šã—ãŸãƒ­ãƒœãƒƒãƒˆä½ç½®
   double tx = pose.tx;
   double ty = pose.ty;
 
-  vector<LPoint2D> scanG;                                // ’n}À•WŒn‚Å‚Ì“_ŒQ
+  vector<LPoint2D> scanG;                                // åœ°å›³åº§æ¨™ç³»ã§ã®ç‚¹ç¾¤
   for(size_t i=0; i<lps.size(); i++) {
     const LPoint2D &lp = lps[i];
-    if (lp.type == ISOLATE)                              // ŒÇ—§“_i–@ü‚È‚µj‚ÍœŠO
+    if (lp.type == ISOLATE)                              // å­¤ç«‹ç‚¹ï¼ˆæ³•ç·šãªã—ï¼‰ã¯é™¤å¤–
       continue;
-    double x = R[0][0]*lp.x + R[0][1]*lp.y + tx;         // ’n}À•WŒn‚É•ÏŠ·
+    double x = R[0][0]*lp.x + R[0][1]*lp.y + tx;         // åœ°å›³åº§æ¨™ç³»ã«å¤‰æ›
     double y = R[1][0]*lp.x + R[1][1]*lp.y + ty;
-    double nx = R[0][0]*lp.nx + R[0][1]*lp.ny;           // –@üƒxƒNƒgƒ‹‚à•ÏŠ·
+    double nx = R[0][0]*lp.nx + R[0][1]*lp.ny;           // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã‚‚å¤‰æ›
     double ny = R[1][0]*lp.nx + R[1][1]*lp.ny;
 
-    LPoint2D mlp(cnt, x, y);                             // V‹K‚É“_‚ğ¶¬
+    LPoint2D mlp(cnt, x, y);                             // æ–°è¦ã«ç‚¹ã‚’ç”Ÿæˆ
     mlp.setNormal(nx, ny);
     mlp.setType(lp.type);
-    scanG.emplace_back(mlp);                             // mlp‚Ívector“à‚ÉƒRƒs[‚³‚ê‚é
+    scanG.emplace_back(mlp);                             // mlpã¯vectorå†…ã«ã‚³ãƒ”ãƒ¼ã•ã‚Œã‚‹
   }
 
-  // “_ŒQ’n}pcmap‚É“o˜^
+  // ç‚¹ç¾¤åœ°å›³pcmapã«ç™»éŒ²
   pcmap->addPose(pose);
   pcmap->addPoints(scanG);
   pcmap->setLastPose(pose);
-  pcmap->setLastScan(scan);          // QÆƒXƒLƒƒƒ“—p‚É•Û‘¶
-  pcmap->makeLocalMap();             // ‹ÇŠ’n}‚ğ¶¬
+  pcmap->setLastScan(scan);          // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç”¨ã«ä¿å­˜
+  pcmap->makeLocalMap();             // å±€æ‰€åœ°å›³ã‚’ç”Ÿæˆ
   
-  printf("ScanMatcher: estPose: tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);    // Šm”F—p
+  printf("ScanMatcher: estPose: tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);    // ç¢ºèªç”¨
 }

--- a/framework/ScanMatcher2D.h
+++ b/framework/ScanMatcher2D.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -27,29 +27,29 @@
 #include "PoseEstimatorICP.h"
 #include "PoseFuser.h"
 
-// ICP‚ğ—p‚¢‚ÄƒXƒLƒƒƒ“ƒ}ƒbƒ`ƒ“ƒO‚ğs‚¤
+// ICPã‚’ç”¨ã„ã¦ã‚¹ã‚­ãƒ£ãƒ³ãƒãƒƒãƒãƒ³ã‚°ã‚’è¡Œã†
 class ScanMatcher2D
 {
 private:
-  int cnt;                                // ˜_—BƒXƒLƒƒƒ“”Ô†‚É‘Î‰
-  Scan2D prevScan;                        // 1‚Â‘O‚ÌƒXƒLƒƒƒ“
-  Pose2D initPose;                        // ’n}‚ÌŒ´“_‚ÌˆÊ’uB’Êí(0,0,0)
+  int cnt;                                // è«–ç†æ™‚åˆ»ã€‚ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã«å¯¾å¿œ
+  Scan2D prevScan;                        // 1ã¤å‰ã®ã‚¹ã‚­ãƒ£ãƒ³
+  Pose2D initPose;                        // åœ°å›³ã®åŸç‚¹ã®ä½ç½®ã€‚é€šå¸¸(0,0,0)
 
-  double scthre;                          // ƒXƒRƒAè‡’lB‚±‚ê‚æ‚è‘å‚«‚¢‚ÆICP¸”s‚Æ‚İ‚È‚·
-  double nthre;                           // g—p“_”è‡’lB‚±‚ê‚æ‚è¬‚³‚¢‚ÆICP¸”s‚Æ‚İ‚È‚·
-  double atd;                             // —İÏ‘–s‹——£BŠm”F—p
-  bool dgcheck;                           // ‘Ş‰»ˆ—‚ğ‚·‚é‚©
+  double scthre;                          // ã‚¹ã‚³ã‚¢é–¾å€¤ã€‚ã“ã‚Œã‚ˆã‚Šå¤§ãã„ã¨ICPå¤±æ•—ã¨ã¿ãªã™
+  double nthre;                           // ä½¿ç”¨ç‚¹æ•°é–¾å€¤ã€‚ã“ã‚Œã‚ˆã‚Šå°ã•ã„ã¨ICPå¤±æ•—ã¨ã¿ãªã™
+  double atd;                             // ç´¯ç©èµ°è¡Œè·é›¢ã€‚ç¢ºèªç”¨
+  bool dgcheck;                           // é€€åŒ–å‡¦ç†ã‚’ã™ã‚‹ã‹
 
-  PoseEstimatorICP *estim;                // ƒƒ{ƒbƒgˆÊ’u„’èŠí
-  PointCloudMap *pcmap;                   // “_ŒQ’n}
-  ScanPointResampler *spres;              // ƒXƒLƒƒƒ““_ŠÔŠu‹Ïˆê‰»
-  ScanPointAnalyser *spana;               // ƒXƒLƒƒƒ““_–@üŒvZ
-  RefScanMaker *rsm;                      // QÆƒXƒLƒƒƒ“¶¬
-  PoseFuser *pfu;                         // ƒZƒ“ƒT—Z‡Ší
-  Eigen::Matrix3d cov;                    // ƒƒ{ƒbƒgˆÚ“®—Ê‚Ì‹¤•ªUs—ñ
-  Eigen::Matrix3d totalCov;               // ƒƒ{ƒbƒgˆÊ’u‚Ì‹¤•ªUs—ñ
+  PoseEstimatorICP *estim;                // ãƒ­ãƒœãƒƒãƒˆä½ç½®æ¨å®šå™¨
+  PointCloudMap *pcmap;                   // ç‚¹ç¾¤åœ°å›³
+  ScanPointResampler *spres;              // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹é–“éš”å‡ä¸€åŒ–
+  ScanPointAnalyser *spana;               // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹æ³•ç·šè¨ˆç®—
+  RefScanMaker *rsm;                      // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç”Ÿæˆ
+  PoseFuser *pfu;                         // ã‚»ãƒ³ã‚µèåˆå™¨
+  Eigen::Matrix3d cov;                    // ãƒ­ãƒœãƒƒãƒˆç§»å‹•é‡ã®å…±åˆ†æ•£è¡Œåˆ—
+  Eigen::Matrix3d totalCov;               // ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®å…±åˆ†æ•£è¡Œåˆ—
 
-  std::vector<PoseCov> poseCovs;          // ƒfƒoƒbƒO—p
+  std::vector<PoseCov> poseCovs;          // ãƒ‡ãƒãƒƒã‚°ç”¨
 
 public:
   ScanMatcher2D() : cnt(-1), scthre(1.0), nthre(50), dgcheck(false), atd(0), pcmap(nullptr), spres(nullptr), spana(nullptr), estim(nullptr), rsm(nullptr), pfu(nullptr) {
@@ -58,7 +58,7 @@ public:
   ~ScanMatcher2D() {
   }
 
-/////// ƒtƒŒ[ƒ€ƒ[ƒN‚Ì‰ü‘¢‰ÓŠ ////////
+/////// ãƒ•ãƒ¬ãƒ¼ãƒ ãƒ¯ãƒ¼ã‚¯ã®æ”¹é€ ç®‡æ‰€ ////////
 
   void setPoseEstimator(PoseEstimatorICP *p) {
     estim = p;
@@ -106,7 +106,7 @@ public:
     return(cov);
   }
 
-  // ƒfƒoƒbƒO—p
+  // ãƒ‡ãƒãƒƒã‚°ç”¨
   std::vector<PoseCov> &getPoseCovs() {
     return(poseCovs);
   }

--- a/framework/ScanPointAnalyser.cpp
+++ b/framework/ScanPointAnalyser.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,48 +16,48 @@
 
 using namespace std;
   
-const double ScanPointAnalyser::FPDMIN = 0.06;      // ScanPointResampler.dthrS‚Æ‚¸‚ç‚·
+const double ScanPointAnalyser::FPDMIN = 0.06;      // ScanPointResampler.dthrSã¨ãšã‚‰ã™
 const double ScanPointAnalyser::FPDMAX = 1.0;
 
 ///////////
 
-// ƒXƒLƒƒƒ““_‚Ì–@üƒxƒNƒgƒ‹‚ğ‹‚ß‚éB‚Ü‚½A’¼üAƒR[ƒiAŒÇ—§‚Ìê‡•ª‚¯‚ğ‚·‚éB
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã‚’æ±‚ã‚ã‚‹ã€‚ã¾ãŸã€ç›´ç·šã€ã‚³ãƒ¼ãƒŠã€å­¤ç«‹ã®å ´åˆåˆ†ã‘ã‚’ã™ã‚‹ã€‚
 void ScanPointAnalyser::analysePoints(vector<LPoint2D> &lps) {
   for (int i=0; i<lps.size(); i++) {
-    LPoint2D &lp = lps[i];                        // ƒXƒLƒƒƒ““_
+    LPoint2D &lp = lps[i];                        // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹
     ptype type;
     Vector2D nL, nR, normal;
-    bool flagL = calNormal(i, lps, -1, nL);        // nL‚Ílp‚Æ¶‘¤‚Ì“_‚Å‹‚ß‚½–@üƒxƒNƒgƒ‹
-    bool flagR = calNormal(i, lps, 1, nR);         // nR‚Ílp‚Æ‰E‘¤‚Ì“_‚Å‹‚ß‚½–@üƒxƒNƒgƒ‹
-    nR.x = -nR.x;                                 // •„†‚ğnL‚Æ‡‚¹‚é
+    bool flagL = calNormal(i, lps, -1, nL);        // nLã¯lpã¨å·¦å´ã®ç‚¹ã§æ±‚ã‚ãŸæ³•ç·šãƒ™ã‚¯ãƒˆãƒ«
+    bool flagR = calNormal(i, lps, 1, nR);         // nRã¯lpã¨å³å´ã®ç‚¹ã§æ±‚ã‚ãŸæ³•ç·šãƒ™ã‚¯ãƒˆãƒ«
+    nR.x = -nR.x;                                 // ç¬¦å·ã‚’nLã¨åˆã›ã‚‹
     nR.y = -nR.y;
     if (flagL) {
-      if (flagR) {                                     // ¶‰E—¼‘¤‚Å–@üƒxƒNƒgƒ‹‚ªŒvZ‰Â”\
-        if (fabs(nL.x*nR.x + nL.y*nR.y) >= costh) {    // —¼‘¤‚Ì–@ü‚ª•½s‚É‹ß‚¢
-          type = LINE;                                 // ’¼ü‚Æ‚İ‚È‚·
+      if (flagR) {                                     // å·¦å³ä¸¡å´ã§æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ãŒè¨ˆç®—å¯èƒ½
+        if (fabs(nL.x*nR.x + nL.y*nR.y) >= costh) {    // ä¸¡å´ã®æ³•ç·šãŒå¹³è¡Œã«è¿‘ã„
+          type = LINE;                                 // ç›´ç·šã¨ã¿ãªã™
         }
-        else {                                         // •½s‚©‚ç‰“‚¯‚ê‚ÎAƒR[ƒi“_‚Æ‚İ‚È‚·
+        else {                                         // å¹³è¡Œã‹ã‚‰é ã‘ã‚Œã°ã€ã‚³ãƒ¼ãƒŠç‚¹ã¨ã¿ãªã™
           type = CORNER;
         }
-        // ¶‰E—¼‘¤‚Ì–@üƒxƒNƒgƒ‹‚Ì•½‹Ï
+        // å·¦å³ä¸¡å´ã®æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã®å¹³å‡
         double dx = nL.x+nR.x;
         double dy = nL.y+nR.y;
         double L = sqrt(dx*dx + dy*dy);
         normal.x = dx/L;
         normal.y = dy/L;
       }
-      else {                       // ¶‘¤‚µ‚©–@üƒxƒNƒgƒ‹‚ª‚Æ‚ê‚È‚©‚Á‚½
+      else {                       // å·¦å´ã—ã‹æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ãŒã¨ã‚Œãªã‹ã£ãŸ
         type = LINE;
         normal = nL;
       }
     }
     else {
-      if (flagR) {                 // ‰E‘¤‚µ‚©–@üƒxƒNƒgƒ‹‚ª‚Æ‚ê‚È‚©‚Á‚½
+      if (flagR) {                 // å³å´ã—ã‹æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ãŒã¨ã‚Œãªã‹ã£ãŸ
         type = LINE;
         normal = nR;
       }
-      else {                       // —¼‘¤‚Æ‚à–@üƒxƒNƒgƒ‹‚ª‚Æ‚ê‚È‚©‚Á‚½
-        type = ISOLATE;            // ŒÇ—§“_‚Æ‚İ‚È‚·
+      else {                       // ä¸¡å´ã¨ã‚‚æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ãŒã¨ã‚Œãªã‹ã£ãŸ
+        type = ISOLATE;            // å­¤ç«‹ç‚¹ã¨ã¿ãªã™
         normal.x = INVALID;
         normal.y = INVALID;
       }
@@ -68,21 +68,21 @@ void ScanPointAnalyser::analysePoints(vector<LPoint2D> &lps) {
   }
 }
   
-  // ’–Ú“_cp‚Ì—¼‘¤‚Ì“_‚ªAcp‚©‚çdminˆÈãdmaxˆÈ‰º‚Ìê‡‚ÉA–@ü‚ğŒvZ‚·‚éB
+  // æ³¨ç›®ç‚¹cpã®ä¸¡å´ã®ç‚¹ãŒã€cpã‹ã‚‰dminä»¥ä¸Šdmaxä»¥ä¸‹ã®å ´åˆã«ã€æ³•ç·šã‚’è¨ˆç®—ã™ã‚‹ã€‚
 bool ScanPointAnalyser::calNormal(int idx, const vector<LPoint2D> &lps, int dir, Vector2D &normal){
-  const LPoint2D &cp = lps[idx];                          // ’–Ú“_
+  const LPoint2D &cp = lps[idx];                          // æ³¨ç›®ç‚¹
   for (int i=idx+dir; i>=0 && i<lps.size(); i+=dir) {
-    const LPoint2D &lp = lps[i];                          // cp‚Ìdiri¶‚©‰Ej‘¤‚Ì“_
+    const LPoint2D &lp = lps[i];                          // cpã®dirï¼ˆå·¦ã‹å³ï¼‰å´ã®ç‚¹
     double dx = lp.x - cp.x;
     double dy = lp.y - cp.y;
     double d = sqrt(dx*dx + dy*dy);
-    if (d>=FPDMIN && d<=FPDMAX) {                         // cp‚Ælp‚Ì‹——£d‚ª“KØ‚È‚ç–@üŒvZ
+    if (d>=FPDMIN && d<=FPDMAX) {                         // cpã¨lpã®è·é›¢dãŒé©åˆ‡ãªã‚‰æ³•ç·šè¨ˆç®—
       normal.x = dy/d;
       normal.y = -dx/d;
       return(true);
     }
       
-    if (d > FPDMAX)                                       // ‚à‚Í‚â‚Ç‚ñ‚Ç‚ñ—£‚ê‚é‚Ì‚ÅA“r’†‚Å‚â‚ß‚é
+    if (d > FPDMAX)                                       // ã‚‚ã¯ã‚„ã©ã‚“ã©ã‚“é›¢ã‚Œã‚‹ã®ã§ã€é€”ä¸­ã§ã‚„ã‚ã‚‹
       break;
   }
 

--- a/framework/ScanPointAnalyser.h
+++ b/framework/ScanPointAnalyser.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+п»ї/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,11 +24,11 @@
 class ScanPointAnalyser
 {
 private:
-  static const double FPDMIN;               // —ЧђЪ“_‚Ж‚МЌЕЏ¬‹——Ј[m]ЃB‚±‚к‚ж‚иЏ¬‚і‚ў‚ЖЊлЌ·‚Є‘е‚«‚­‚И‚й‚М‚Е–@ђьЊvЋZ‚ЙЋg‚н‚И‚ўЃB
-  static const double FPDMAX;               // —ЧђЪ“_‚Ж‚МЌЕ‘е‹——Ј[m]ЃB‚±‚к‚ж‚и‘е‚«‚ў‚Ж•sA‘±‚Ж‚Э‚И‚µ‚Д–@ђьЊvЋZ‚ЙЋg‚н‚И‚ўЃB
-  static const int CRTHRE = 45;             // –@ђь•ыЊь•П‰»‚Ми‡’l[“x]ЃB‚±‚к‚ж‚и‘е‚«‚ў‚ЖѓRЃ[ѓi“_‚Ж‚Э‚И‚·ЃB
+  static const double FPDMIN;               // йљЈжЋҐз‚№гЃЁгЃ®жњЂе°Џи·ќй›ў[m]гЂ‚гЃ“г‚Њг‚€г‚Ље°ЏгЃ•гЃ„гЃЁиЄ¤е·®гЃЊе¤§гЃЌгЃЏгЃЄг‚‹гЃ®гЃ§жі•з·љиЁ€з®—гЃ«дЅїг‚ЏгЃЄгЃ„гЂ‚
+  static const double FPDMAX;               // йљЈжЋҐз‚№гЃЁгЃ®жњЂе¤§и·ќй›ў[m]гЂ‚гЃ“г‚Њг‚€г‚Ље¤§гЃЌгЃ„гЃЁдёЌйЂЈз¶љгЃЁгЃїгЃЄгЃ—гЃ¦жі•з·љиЁ€з®—гЃ«дЅїг‚ЏгЃЄгЃ„гЂ‚
+  static const int CRTHRE = 45;             // жі•з·љж–№еђ‘е¤‰еЊ–гЃ®й–ѕеЂ¤[еє¦]гЂ‚гЃ“г‚Њг‚€г‚Ље¤§гЃЌгЃ„гЃЁг‚ігѓјгѓЉз‚№гЃЁгЃїгЃЄгЃ™гЂ‚
   static const int INVALID = -1;
-  double costh;                             // Ќ¶‰E‚М–@ђь•ыЊь‚МђH‚ў€б‚ў‚Ми‡’l
+  double costh;                             // е·¦еЏігЃ®жі•з·љж–№еђ‘гЃ®йЈџгЃ„йЃ•гЃ„гЃ®й–ѕеЂ¤
 
 public:
   ScanPointAnalyser() : costh(cos(DEG2RAD(CRTHRE))) {

--- a/framework/ScanPointResampler.cpp
+++ b/framework/ScanPointResampler.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -19,56 +19,56 @@ using namespace std;
 /////////
 
 void ScanPointResampler::resamplePoints(Scan2D *scan) {
-  vector<LPoint2D> &lps = scan->lps;           // ƒXƒLƒƒƒ““_ŒQ
+  vector<LPoint2D> &lps = scan->lps;           // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
   if (lps.size() == 0)
     return;
 
-  vector<LPoint2D> newLps;                     // ƒŠƒTƒ“ƒvƒ‹Œã‚Ì“_ŒQ
+  vector<LPoint2D> newLps;                     // ãƒªã‚µãƒ³ãƒ—ãƒ«å¾Œã®ç‚¹ç¾¤
 
-  dis = 0;                                     // dis‚Í—İÏ‹——£
+  dis = 0;                                     // disã¯ç´¯ç©è·é›¢
   LPoint2D lp = lps[0];
   LPoint2D prevLp = lp;
   LPoint2D np(lp.sid, lp.x, lp.y);
-  newLps.emplace_back(np);                     // Å‰‚Ì“_‚Í“ü‚ê‚é
+  newLps.emplace_back(np);                     // æœ€åˆã®ç‚¹ã¯å…¥ã‚Œã‚‹
   for (size_t i=1; i<lps.size(); i++) {
-    lp = lps[i];                               // ƒXƒLƒƒƒ““_
+    lp = lps[i];                               // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹
     bool inserted=false;
 
     bool exist = findInterpolatePoint(lp, prevLp, np, inserted);
 
-    if (exist) {                               // “ü‚ê‚é“_‚ª‚ ‚é
-      newLps.emplace_back(np);                 // V‚µ‚¢“_np‚ğ“ü‚ê‚é
-      prevLp = np;                             // np‚ª’¼‘O“_‚É‚È‚é
-      dis = 0;                                 // —İÏ‹——£‚ğƒŠƒZƒbƒg
-      if (inserted)                            // lp‚Ì‘O‚Å•âŠÔ“_‚ğ“ü‚ê‚½‚Ì‚ÅAlp‚ğ‚à‚¤ˆê“x‚â‚é
+    if (exist) {                               // å…¥ã‚Œã‚‹ç‚¹ãŒã‚ã‚‹
+      newLps.emplace_back(np);                 // æ–°ã—ã„ç‚¹npã‚’å…¥ã‚Œã‚‹
+      prevLp = np;                             // npãŒç›´å‰ç‚¹ã«ãªã‚‹
+      dis = 0;                                 // ç´¯ç©è·é›¢ã‚’ãƒªã‚»ãƒƒãƒˆ
+      if (inserted)                            // lpã®å‰ã§è£œé–“ç‚¹ã‚’å…¥ã‚ŒãŸã®ã§ã€lpã‚’ã‚‚ã†ä¸€åº¦ã‚„ã‚‹
         i--;
     }
     else
-      prevLp = lp;                             // ¡‚Ìlp‚ª’¼‘O“_‚É‚È‚é
+      prevLp = lp;                             // ä»Šã®lpãŒç›´å‰ç‚¹ã«ãªã‚‹
   }
 
   scan->setLps(newLps);
 
-  printf("lps.size=%lu, newLps.size=%lu\n", lps.size(), newLps.size());    // Šm”F—p
+  printf("lps.size=%lu, newLps.size=%lu\n", lps.size(), newLps.size());    // ç¢ºèªç”¨
 }
 
 bool ScanPointResampler::findInterpolatePoint(const LPoint2D &cp, const LPoint2D &pp, LPoint2D &np, bool &inserted) {
   double dx = cp.x - pp.x;
   double dy = cp.y - pp.y;
-  double L = sqrt(dx*dx+dy*dy);             // Œ»İ“_cp‚Æ’¼‘O“_pp‚Ì‹——£
-  if (dis+L < dthreS) {                     // —\‘ª—İÏ‹——£(dis+L)‚ªdthreS‚æ‚è¬‚³‚¢“_‚Ííœ
-    dis += L;                               // dis‚É‰ÁZ
+  double L = sqrt(dx*dx+dy*dy);             // ç¾åœ¨ç‚¹cpã¨ç›´å‰ç‚¹ppã®è·é›¢
+  if (dis+L < dthreS) {                     // äºˆæ¸¬ç´¯ç©è·é›¢(dis+L)ãŒdthreSã‚ˆã‚Šå°ã•ã„ç‚¹ã¯å‰Šé™¤
+    dis += L;                               // disã«åŠ ç®—
     return(false);
   }
-  else if (dis+L >= dthreL) {               // —\‘ª—İÏ‹——£‚ªdthreL‚æ‚è‘å‚«‚¢“_‚Í•âŠÔ‚¹‚¸A‚»‚Ì‚Ü‚Üc‚·
+  else if (dis+L >= dthreL) {               // äºˆæ¸¬ç´¯ç©è·é›¢ãŒdthreLã‚ˆã‚Šå¤§ãã„ç‚¹ã¯è£œé–“ã›ãšã€ãã®ã¾ã¾æ®‹ã™
     np.setData(cp.sid, cp.x, cp.y);
   }
-  else {                                    // —\‘ª—İÏ‹——£‚ªdthreS‚ğ’´‚¦‚½‚çAdthreS‚É‚È‚é‚æ‚¤‚É•âŠÔ‚·‚é
+  else {                                    // äºˆæ¸¬ç´¯ç©è·é›¢ãŒdthreSã‚’è¶…ãˆãŸã‚‰ã€dthreSã«ãªã‚‹ã‚ˆã†ã«è£œé–“ã™ã‚‹
     double ratio = (dthreS-dis)/L;
-    double x2 = dx*ratio + pp.x;            // ­‚µL‚Î‚µ‚Ä‹——£‚ªdthreS‚É‚È‚éˆÊ’u
+    double x2 = dx*ratio + pp.x;            // å°‘ã—ä¼¸ã°ã—ã¦è·é›¢ãŒdthreSã«ãªã‚‹ä½ç½®
     double y2 = dy*ratio + pp.y;
     np.setData(cp.sid, x2, y2);
-    inserted = true;                        // cp‚æ‚è‘O‚Énp‚ğ“ü‚ê‚½‚Æ‚¢‚¤ƒtƒ‰ƒO
+    inserted = true;                        // cpã‚ˆã‚Šå‰ã«npã‚’å…¥ã‚ŒãŸã¨ã„ã†ãƒ•ãƒ©ã‚°
   }
  
   return(true);

--- a/framework/ScanPointResampler.h
+++ b/framework/ScanPointResampler.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,9 +24,9 @@
 class ScanPointResampler
 {
 private:
-  double dthreS;                     // “_‚Ì‹——£ŠÔŠu[m]
-  double dthreL;                     // “_‚Ì‹——£è‡’l[m]B‚±‚ÌŠÔŠu‚ğ’´‚¦‚½‚ç•âŠÔ‚µ‚È‚¢
-  double dis;                        // —İÏ‹——£Bì‹Æ—p
+  double dthreS;                     // ç‚¹ã®è·é›¢é–“éš”[m]
+  double dthreL;                     // ç‚¹ã®è·é›¢é–¾å€¤[m]ã€‚ã“ã®é–“éš”ã‚’è¶…ãˆãŸã‚‰è£œé–“ã—ãªã„
+  double dis;                        // ç´¯ç©è·é›¢ã€‚ä½œæ¥­ç”¨
 
 public:
   ScanPointResampler() : dthreS(0.05), dthreL(0.25), dis(0) {

--- a/framework/SensorDataReader.cpp
+++ b/framework/SensorDataReader.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,64 +16,64 @@
 
 using namespace std;
 
-// ƒtƒ@ƒCƒ‹‚©‚çƒXƒLƒƒƒ“‚ğ1ŒÂ“Ç‚Ş
+// ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰ã‚¹ã‚­ãƒ£ãƒ³ã‚’1å€‹èª­ã‚€
 bool SensorDataReader::loadScan(size_t cnt, Scan2D &scan) {
   bool isScan=false;
-  while (!inFile.eof() && !isScan) {     // ƒXƒLƒƒƒ“‚ğ“Ç‚Ş‚Ü‚Å‘±‚¯‚é
+  while (!inFile.eof() && !isScan) {     // ã‚¹ã‚­ãƒ£ãƒ³ã‚’èª­ã‚€ã¾ã§ç¶šã‘ã‚‹
     isScan = loadLaserScan(cnt, scan);
   }
 
   if (isScan) 
-    return(false);                       // ‚Ü‚¾ƒtƒ@ƒCƒ‹‚ª‘±‚­‚Æ‚¢‚¤ˆÓ–¡
+    return(false);                       // ã¾ã ãƒ•ã‚¡ã‚¤ãƒ«ãŒç¶šãã¨ã„ã†æ„å‘³
   else
-    return(true);                        // ƒtƒ@ƒCƒ‹‚ªI‚í‚Á‚½‚Æ‚¢‚¤ˆÓ–¡
+    return(true);                        // ãƒ•ã‚¡ã‚¤ãƒ«ãŒçµ‚ã‚ã£ãŸã¨ã„ã†æ„å‘³
 }
 
 //////////////
 
-// ƒtƒ@ƒCƒ‹‚©‚ç€–Ú1ŒÂ‚ğ“Ç‚ŞB“Ç‚ñ‚¾€–Ú‚ªƒXƒLƒƒƒ“‚È‚çtrue‚ğ•Ô‚·B
+// ãƒ•ã‚¡ã‚¤ãƒ«ã‹ã‚‰é …ç›®1å€‹ã‚’èª­ã‚€ã€‚èª­ã‚“ã é …ç›®ãŒã‚¹ã‚­ãƒ£ãƒ³ãªã‚‰trueã‚’è¿”ã™ã€‚
 bool SensorDataReader::loadLaserScan(size_t cnt, Scan2D &scan) {
-  string type;                           // ƒtƒ@ƒCƒ‹“à‚Ì€–Úƒ‰ƒxƒ‹
+  string type;                           // ãƒ•ã‚¡ã‚¤ãƒ«å†…ã®é …ç›®ãƒ©ãƒ™ãƒ«
   inFile >> type;
-  if (type == "LASERSCAN") {             // ƒXƒLƒƒƒ“‚Ìê‡
+  if (type == "LASERSCAN") {             // ã‚¹ã‚­ãƒ£ãƒ³ã®å ´åˆ
     scan.setSid(cnt);
 
     int sid, sec, nsec;
-    inFile >> sid >> sec >> nsec;        // ‚±‚ê‚ç‚Íg‚í‚È‚¢
+    inFile >> sid >> sec >> nsec;        // ã“ã‚Œã‚‰ã¯ä½¿ã‚ãªã„
 
     vector<LPoint2D> lps;
-    int pnum;                            // ƒXƒLƒƒƒ““_”
+    int pnum;                            // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹æ•°
     inFile >> pnum;
     lps.reserve(pnum);
     for (int i=0; i<pnum; i++) {
       float angle, range;
-      inFile >> angle >> range;          // ƒXƒLƒƒƒ““_‚Ì•ûˆÊ‚Æ‹——£
-      angle += angleOffset;              // ƒŒ[ƒUƒXƒLƒƒƒi‚Ì•ûŒüƒIƒtƒZƒbƒg‚ğl—¶
+      inFile >> angle >> range;          // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®æ–¹ä½ã¨è·é›¢
+      angle += angleOffset;              // ãƒ¬ãƒ¼ã‚¶ã‚¹ã‚­ãƒ£ãƒŠã®æ–¹å‘ã‚ªãƒ•ã‚»ãƒƒãƒˆã‚’è€ƒæ…®
       if (range <= Scan2D::MIN_SCAN_RANGE || range >= Scan2D::MAX_SCAN_RANGE) {
-//      if (range <= Scan2D::MIN_SCAN_RANGE || range >= 3.5) {         // ‚í‚´‚Æ‘Ş‰»‚ğ‹N‚±‚µ‚â‚·‚­
+//      if (range <= Scan2D::MIN_SCAN_RANGE || range >= 3.5) {         // ã‚ã–ã¨é€€åŒ–ã‚’èµ·ã“ã—ã‚„ã™ã
         continue;
       }
 
       LPoint2D lp;
-      lp.setSid(cnt);                    // ƒXƒLƒƒƒ“”Ô†‚Ícnti’Ê‚µ”Ô†j‚É‚·‚é
-      lp.calXY(range, angle);            // angle,range‚©‚ç“_‚ÌˆÊ’uxy‚ğŒvZ
+      lp.setSid(cnt);                    // ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ã¯cntï¼ˆé€šã—ç•ªå·ï¼‰ã«ã™ã‚‹
+      lp.calXY(range, angle);            // angle,rangeã‹ã‚‰ç‚¹ã®ä½ç½®xyã‚’è¨ˆç®—
       lps.emplace_back(lp);
     }
     scan.setLps(lps);
 
-    // ƒXƒLƒƒƒ“‚É‘Î‰‚·‚éƒIƒhƒƒgƒŠî•ñ
+    // ã‚¹ã‚­ãƒ£ãƒ³ã«å¯¾å¿œã™ã‚‹ã‚ªãƒ‰ãƒ¡ãƒˆãƒªæƒ…å ±
     Pose2D &pose = scan.pose;
     inFile >> pose.tx >> pose.ty;
     double th;
     inFile >> th;
-    pose.setAngle(RAD2DEG(th));          // ƒIƒhƒƒgƒŠŠp“x‚Íƒ‰ƒWƒAƒ“‚È‚Ì‚Å“x‚É‚·‚é
+    pose.setAngle(RAD2DEG(th));          // ã‚ªãƒ‰ãƒ¡ãƒˆãƒªè§’åº¦ã¯ãƒ©ã‚¸ã‚¢ãƒ³ãªã®ã§åº¦ã«ã™ã‚‹
     pose.calRmat();
 
     return(true);
   }
-  else {                                 // ƒXƒLƒƒƒ“ˆÈŠO‚Ìê‡
+  else {                                 // ã‚¹ã‚­ãƒ£ãƒ³ä»¥å¤–ã®å ´åˆ
     string line;
-    getline(inFile, line);               // “Ç‚İ”ò‚Î‚·
+    getline(inFile, line);               // èª­ã¿é£›ã°ã™
 
     return(false);
   }

--- a/framework/SensorDataReader.h
+++ b/framework/SensorDataReader.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -28,8 +28,8 @@
 class SensorDataReader
 {
 private:
-  int angleOffset;                      // ƒŒ[ƒUƒXƒLƒƒƒi‚Æƒƒ{ƒbƒg‚ÌŒü‚«‚ÌƒIƒtƒZƒbƒg
-  std::ifstream inFile;                 // ƒf[ƒ^ƒtƒ@ƒCƒ‹
+  int angleOffset;                      // ãƒ¬ãƒ¼ã‚¶ã‚¹ã‚­ãƒ£ãƒŠã¨ãƒ­ãƒœãƒƒãƒˆã®å‘ãã®ã‚ªãƒ•ã‚»ãƒƒãƒˆ
+  std::ifstream inFile;                 // ãƒ‡ãƒ¼ã‚¿ãƒ•ã‚¡ã‚¤ãƒ«
 
 public:
   SensorDataReader() : angleOffset(180) {

--- a/framework/SlamBackEnd.cpp
+++ b/framework/SlamBackEnd.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,7 +17,7 @@
 
 using namespace std;
 
-////////// ƒ|[ƒY’²® //////////
+////////// ãƒãƒ¼ã‚ºèª¿æ•´ //////////
 
 Pose2D SlamBackEnd::adjustPoses() {
 //  pg->printArcs();
@@ -26,7 +26,7 @@ Pose2D SlamBackEnd::adjustPoses() {
   newPoses.clear();
 
   P2oDriver2D p2o;
-  p2o.doP2o(*pg, newPoses, 5);                 // 5‰ñ‚­‚è•Ô‚·
+  p2o.doP2o(*pg, newPoses, 5);                 // 5å›ãã‚Šè¿”ã™
 
   return(newPoses.back());
 }
@@ -34,15 +34,15 @@ Pose2D SlamBackEnd::adjustPoses() {
 /////////////////////////////
 
 void SlamBackEnd::remakeMaps() {
-  // PoseGraph‚ÌC³
-  vector<PoseNode*> &pnodes = pg->nodes;      // ƒ|[ƒYƒm[ƒh
+  // PoseGraphã®ä¿®æ­£
+  vector<PoseNode*> &pnodes = pg->nodes;      // ãƒãƒ¼ã‚ºãƒãƒ¼ãƒ‰
   for (size_t i=0; i<newPoses.size(); i++) {
     Pose2D &npose = newPoses[i];
-    PoseNode *pnode = pnodes[i];              // ƒm[ƒh‚Íƒƒ{ƒbƒgˆÊ’u‚Æ1:1‘Î‰
-    pnode->setPose(npose);                    // Šeƒm[ƒh‚ÌˆÊ’u‚ğXV
+    PoseNode *pnode = pnodes[i];              // ãƒãƒ¼ãƒ‰ã¯ãƒ­ãƒœãƒƒãƒˆä½ç½®ã¨1:1å¯¾å¿œ
+    pnode->setPose(npose);                    // å„ãƒãƒ¼ãƒ‰ã®ä½ç½®ã‚’æ›´æ–°
   }
   printf("newPoses.size=%lu, nodes.size=%lu\n", newPoses.size(), pnodes.size());
 
-  // PointCloudMap‚ÌC³
+  // PointCloudMapã®ä¿®æ­£
   pcmap->remakeMaps(newPoses);
 }

--- a/framework/SlamBackEnd.h
+++ b/framework/SlamBackEnd.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -24,9 +24,9 @@
 class SlamBackEnd
 {
 private:
-  std::vector<Pose2D> newPoses;            // ƒ|[ƒY’²®Œã‚Ìp¨
-  PointCloudMap *pcmap;                    // “_ŒQ’n}
-  PoseGraph *pg;                           // ƒ|[ƒYƒOƒ‰ƒt
+  std::vector<Pose2D> newPoses;            // ãƒãƒ¼ã‚ºèª¿æ•´å¾Œã®å§¿å‹¢
+  PointCloudMap *pcmap;                    // ç‚¹ç¾¤åœ°å›³
+  PoseGraph *pg;                           // ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•
 
 public:
   SlamBackEnd() {

--- a/framework/SlamFrontEnd.h
+++ b/framework/SlamFrontEnd.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -25,18 +25,18 @@
 
 ////////
 
-// SLAMƒtƒƒ“ƒgƒGƒ“ƒhBƒƒ{ƒbƒgˆÊ’u„’èA’n}¶¬Aƒ‹[ƒv•Â‚¶‚İ‚ğæ‚èdØ‚éB
+// SLAMãƒ•ãƒ­ãƒ³ãƒˆã‚¨ãƒ³ãƒ‰ã€‚ãƒ­ãƒœãƒƒãƒˆä½ç½®æ¨å®šã€åœ°å›³ç”Ÿæˆã€ãƒ«ãƒ¼ãƒ—é–‰ã˜è¾¼ã¿ã‚’å–ã‚Šä»•åˆ‡ã‚‹ã€‚
 class SlamFrontEnd
 {
 private:
-  int cnt;                               // ˜_—
-  int keyframeSkip;                      // ƒL[ƒtƒŒ[ƒ€ŠÔŠu
+  int cnt;                               // è«–ç†æ™‚åˆ»
+  int keyframeSkip;                      // ã‚­ãƒ¼ãƒ•ãƒ¬ãƒ¼ãƒ é–“éš”
 
-  PointCloudMap *pcmap;                  // “_ŒQ’n}
-  PoseGraph *pg;                         // ƒ|[ƒYƒOƒ‰ƒt
-  ScanMatcher2D *smat;                   // ƒXƒLƒƒƒ“ƒ}ƒbƒ`ƒ“ƒO
-  LoopDetector *lpd;                     // ƒ‹[ƒvŒŸoŠí
-  SlamBackEnd sback;                     // SLAMƒoƒbƒNƒGƒ“ƒh
+  PointCloudMap *pcmap;                  // ç‚¹ç¾¤åœ°å›³
+  PoseGraph *pg;                         // ãƒãƒ¼ã‚ºã‚°ãƒ©ãƒ•
+  ScanMatcher2D *smat;                   // ã‚¹ã‚­ãƒ£ãƒ³ãƒãƒƒãƒãƒ³ã‚°
+  LoopDetector *lpd;                     // ãƒ«ãƒ¼ãƒ—æ¤œå‡ºå™¨
+  SlamBackEnd sback;                     // SLAMãƒãƒƒã‚¯ã‚¨ãƒ³ãƒ‰
 
 public:
   SlamFrontEnd()  : cnt(0), keyframeSkip(10), smat(nullptr), lpd(nullptr) {
@@ -83,12 +83,12 @@ public:
     smat->setDgCheck(p);
   }
 
-  // ƒfƒoƒbƒO—p
+  // ãƒ‡ãƒãƒƒã‚°ç”¨
   std::vector<LoopMatch> &getLoopMatches() {
     return(lpd->getLoopMatches());
   }
 
-  // ƒfƒoƒbƒO—p
+  // ãƒ‡ãƒãƒƒã‚°ç”¨
   std::vector<PoseCov> &getPoseCovs() {
     return(smat->getPoseCovs());
   }

--- a/hook/CMakeLists.txt
+++ b/hook/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT(hook)
+﻿PROJECT(hook)
 
 cmake_minimum_required(VERSION 2.8)
 

--- a/hook/CostFunctionED.cpp
+++ b/hook/CostFunctionED.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,37 +16,37 @@
 
 using namespace std;
 
-// “_ŠÔ‹——£‚É‚æ‚éICP‚ÌƒRƒXƒgŠÖ”
+// ç‚¹é–“è·é›¢ã«ã‚ˆã‚‹ICPã®ã‚³ã‚¹ãƒˆé–¢æ•°
 double CostFunctionED::calValue(double tx, double ty, double th) {
   double a = DEG2RAD(th);
   double error=0;
   int pn=0;
   int nn=0;
   for (size_t i=0; i<curLps.size(); i++) {
-    const LPoint2D *clp = curLps[i];             // Œ»İƒXƒLƒƒƒ“‚Ì“_
-    const LPoint2D *rlp = refLps[i];             // clp‚É‘Î‰‚·‚éQÆƒXƒLƒƒƒ“‚Ì“_
+    const LPoint2D *clp = curLps[i];             // ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
+    const LPoint2D *rlp = refLps[i];             // clpã«å¯¾å¿œã™ã‚‹å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
 
     double cx = clp->x;
     double cy = clp->y;
-    double x = cos(a)*cx - sin(a)*cy + tx;       // clp‚ğQÆƒXƒLƒƒƒ“‚ÌÀ•WŒn‚É•ÏŠ·
+    double x = cos(a)*cx - sin(a)*cy + tx;       // clpã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®åº§æ¨™ç³»ã«å¤‰æ›
     double y = sin(a)*cx + cos(a)*cy + ty;
 
-    double edis = (x - rlp->x)*(x - rlp->x) + (y - rlp->y)*(y - rlp->y);     // “_ŠÔ‹——£
+    double edis = (x - rlp->x)*(x - rlp->x) + (y - rlp->y)*(y - rlp->y);     // ç‚¹é–“è·é›¢
 
     if (edis <= evlimit*evlimit)
-      ++pn;                                      // Œë·‚ª¬‚³‚¢“_‚Ì”
+      ++pn;                                      // èª¤å·®ãŒå°ã•ã„ç‚¹ã®æ•°
 
-    error += edis;                               // Še“_‚ÌŒë·‚ğ—İÏ
+    error += edis;                               // å„ç‚¹ã®èª¤å·®ã‚’ç´¯ç©
 
     ++nn;
   }
 
-  error = (nn>0)? error/nn : HUGE_VAL;           // •½‹Ï‚ğ‚Æ‚éB—LŒø“_”‚ª0‚È‚çA’l‚ÍHUGE_VAL
-  pnrate = 1.0*pn/nn;                            // Œë·‚ª¬‚³‚¢“_‚Ì”ä—¦
+  error = (nn>0)? error/nn : HUGE_VAL;           // å¹³å‡ã‚’ã¨ã‚‹ã€‚æœ‰åŠ¹ç‚¹æ•°ãŒ0ãªã‚‰ã€å€¤ã¯HUGE_VAL
+  pnrate = 1.0*pn/nn;                            // èª¤å·®ãŒå°ã•ã„ç‚¹ã®æ¯”ç‡
 
-//  printf("CostFunctionED: error=%g, pnrate=%g, evlimit=%g\n", error, pnrate, evlimit);     // Šm”F—p
+//  printf("CostFunctionED: error=%g, pnrate=%g, evlimit=%g\n", error, pnrate, evlimit);     // ç¢ºèªç”¨
 
-  error *= 100;                                  // •]‰¿’l‚ª¬‚³‚­‚È‚è‚·‚¬‚È‚¢‚æ‚¤100‚©‚¯‚éB
+  error *= 100;                                  // è©•ä¾¡å€¤ãŒå°ã•ããªã‚Šã™ããªã„ã‚ˆã†100ã‹ã‘ã‚‹ã€‚
 
   return(error);
 }

--- a/hook/CostFunctionED.h
+++ b/hook/CostFunctionED.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),

--- a/hook/CostFunctionPD.cpp
+++ b/hook/CostFunctionPD.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -16,7 +16,7 @@
 
 using namespace std;
 
-// ‚’¼‹——£‚É‚æ‚éƒRƒXƒgŠÖ”
+// å‚ç›´è·é›¢ã«ã‚ˆã‚‹ã‚³ã‚¹ãƒˆé–¢æ•°
 double CostFunctionPD::calValue(double tx, double ty, double th) {
   double a = DEG2RAD(th);
 
@@ -24,33 +24,33 @@ double CostFunctionPD::calValue(double tx, double ty, double th) {
   int pn=0;
   int nn=0;
   for (size_t i=0; i<curLps.size(); i++) {
-    const LPoint2D *clp = curLps[i];             // Œ»İƒXƒLƒƒƒ“‚Ì“_
-    const LPoint2D *rlp = refLps[i];             // clp‚É‘Î‰‚·‚éQÆƒXƒLƒƒƒ“‚Ì“_
+    const LPoint2D *clp = curLps[i];             // ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
+    const LPoint2D *rlp = refLps[i];             // clpã«å¯¾å¿œã™ã‚‹å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
 
-    if (rlp->type != LINE)                       // ’¼üã‚Ì“_‚Å‚È‚¯‚ê‚Îg‚í‚È‚¢
+    if (rlp->type != LINE)                       // ç›´ç·šä¸Šã®ç‚¹ã§ãªã‘ã‚Œã°ä½¿ã‚ãªã„
       continue;
  
     double cx = clp->x;
     double cy = clp->y;
-    double x = cos(a)*cx - sin(a)*cy + tx;       // clp‚ğQÆƒXƒLƒƒƒ“‚ÌÀ•WŒn‚É•ÏŠ·
+    double x = cos(a)*cx - sin(a)*cy + tx;       // clpã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®åº§æ¨™ç³»ã«å¤‰æ›
     double y = sin(a)*cx + cos(a)*cy + ty;
 
-    double pdis = (x - rlp->x)*rlp->nx + (y - rlp->y)*rlp->ny;         // ‚’¼‹——£
+    double pdis = (x - rlp->x)*rlp->nx + (y - rlp->y)*rlp->ny;         // å‚ç›´è·é›¢
 
     double er = pdis*pdis;
     if (er <= evlimit*evlimit)
-      ++pn;                                      // Œë·‚ª¬‚³‚¢“_‚Ì”
+      ++pn;                                      // èª¤å·®ãŒå°ã•ã„ç‚¹ã®æ•°
 
-    error += er;                                 // Še“_‚ÌŒë·‚ğ—İÏ
+    error += er;                                 // å„ç‚¹ã®èª¤å·®ã‚’ç´¯ç©
     ++nn;
   }
 
-  error = (nn>0)? error/nn : HUGE_VAL;           // —LŒø“_”‚ª0‚È‚çA’l‚ÍHUGE_VAL
-  pnrate = 1.0*pn/nn;                            // Œë·‚ª¬‚³‚¢“_‚Ì”ä—¦
+  error = (nn>0)? error/nn : HUGE_VAL;           // æœ‰åŠ¹ç‚¹æ•°ãŒ0ãªã‚‰ã€å€¤ã¯HUGE_VAL
+  pnrate = 1.0*pn/nn;                            // èª¤å·®ãŒå°ã•ã„ç‚¹ã®æ¯”ç‡
 
-//  printf("CostFunctionPD: error=%g, pnrate=%g, evlimit=%g\n", error, pnrate, evlimit);     // Šm”F—p
+//  printf("CostFunctionPD: error=%g, pnrate=%g, evlimit=%g\n", error, pnrate, evlimit);     // ç¢ºèªç”¨
 
-  error *= 100;                                  // •]‰¿’l‚ª¬‚³‚­‚È‚è‚·‚¬‚È‚¢‚æ‚¤100‚©‚¯‚éB
+  error *= 100;                                  // è©•ä¾¡å€¤ãŒå°ã•ããªã‚Šã™ããªã„ã‚ˆã†100ã‹ã‘ã‚‹ã€‚
 
   return(error);
 }

--- a/hook/CostFunctionPD.h
+++ b/hook/CostFunctionPD.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),

--- a/hook/DataAssociatorGT.cpp
+++ b/hook/DataAssociatorGT.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,28 +18,28 @@
 using namespace std;
 
 
-// Œ»İƒXƒLƒƒƒ“curScan‚ÌŠeƒXƒLƒƒƒ““_‚ğpredPose‚ÅÀ•W•ÏŠ·‚µ‚½ˆÊ’u‚ÉÅ‚à‹ß‚¢“_‚ğŒ©‚Â‚¯‚é
+// ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³curScanã®å„ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã‚’predPoseã§åº§æ¨™å¤‰æ›ã—ãŸä½ç½®ã«æœ€ã‚‚è¿‘ã„ç‚¹ã‚’è¦‹ã¤ã‘ã‚‹
 double DataAssociatorGT::findCorrespondence(const Scan2D *curScan, const Pose2D &predPose) {
-  boost::timer tim;                                 // ˆ—ŠÔ‘ª’è—p
+  boost::timer tim;                                 // å‡¦ç†æ™‚é–“æ¸¬å®šç”¨
 
-  curLps.clear();                                   // ‘Î‰‚Ã‚¯Œ»İƒXƒLƒƒƒ““_ŒQ‚ğ‹ó‚É‚·‚é
-  refLps.clear();                                   // ‘Î‰‚Ã‚¯QÆƒXƒLƒƒƒ““_ŒQ‚ğ‹ó‚É‚·‚é
+  curLps.clear();                                   // å¯¾å¿œã¥ã‘ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’ç©ºã«ã™ã‚‹
+  refLps.clear();                                   // å¯¾å¿œã¥ã‘å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’ç©ºã«ã™ã‚‹
 
   for (size_t i=0; i<curScan->lps.size(); i++) {
-    const LPoint2D *clp = &(curScan->lps[i]);       // Œ»İƒXƒLƒƒƒ“‚Ì“_Bƒ|ƒCƒ“ƒ^‚ÅB
+    const LPoint2D *clp = &(curScan->lps[i]);       // ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ã€‚ãƒã‚¤ãƒ³ã‚¿ã§ã€‚
 
-    // Šiqƒe[ƒuƒ‹‚É‚æ‚èÅ‹ß–T“_‚ğ‹‚ß‚éBŠiqƒe[ƒuƒ‹“à‚É‹——£è‡’ldthre‚ª‚ ‚é‚±‚Æ‚É’ˆÓB
+    // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ã‚ˆã‚Šæœ€è¿‘å‚ç‚¹ã‚’æ±‚ã‚ã‚‹ã€‚æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«å†…ã«è·é›¢é–¾å€¤dthreãŒã‚ã‚‹ã“ã¨ã«æ³¨æ„ã€‚
     const LPoint2D *rlp = nntab.findClosestPoint(clp, predPose);
 
     if (rlp != nullptr) {
-      curLps.push_back(clp);                        // Å‹ß–T“_‚ª‚ ‚ê‚Î“o˜^
+      curLps.push_back(clp);                        // æœ€è¿‘å‚ç‚¹ãŒã‚ã‚Œã°ç™»éŒ²
       refLps.push_back(rlp);
     }
   }
 
-  double ratio = (1.0*curLps.size())/curScan->lps.size();         // ‘Î‰‚ª‚Æ‚ê‚½“_‚Ì”ä—¦
+  double ratio = (1.0*curLps.size())/curScan->lps.size();         // å¯¾å¿œãŒã¨ã‚ŒãŸç‚¹ã®æ¯”ç‡
 
-//  double t1 = 1000*tim.elapsed();                   // ˆ—ŠÔ
+//  double t1 = 1000*tim.elapsed();                   // å‡¦ç†æ™‚é–“
 //  printf("Elapsed time: dassGT=%g\n", t1);
 
   return(ratio);

--- a/hook/DataAssociatorGT.h
+++ b/hook/DataAssociatorGT.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,11 +18,11 @@
 #include "DataAssociator.h"
 #include "NNGridTable.h"
 
-// Šiqƒe[ƒuƒ‹‚ğ—p‚¢‚ÄAŒ»İƒXƒLƒƒƒ“‚ÆQÆƒXƒLƒƒƒ“ŠÔ‚Ì“_‚Ì‘Î‰‚Ã‚¯‚ğs‚¤
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã‚’ç”¨ã„ã¦ã€ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã¨å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³é–“ã®ç‚¹ã®å¯¾å¿œã¥ã‘ã‚’è¡Œã†
 class DataAssociatorGT : public DataAssociator
 {
 private:
-  NNGridTable nntab;                        // Šiqƒe[ƒuƒ‹
+  NNGridTable nntab;                        // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«
   
 public:
   DataAssociatorGT() {
@@ -31,11 +31,11 @@ public:
   ~DataAssociatorGT() {
   }
   
-  // QÆƒXƒLƒƒƒ“‚Ì“_rlps‚ğƒ|ƒCƒ“ƒ^‚É‚µ‚Änntab‚É“ü‚ê‚é
+  // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹rlpsã‚’ãƒã‚¤ãƒ³ã‚¿ã«ã—ã¦nntabã«å…¥ã‚Œã‚‹
   virtual void setRefBase(const std::vector<LPoint2D> &rlps) {
     nntab.clear();
     for (size_t i=0; i<rlps.size(); i++) 
-      nntab.addPoint(&rlps[i]);              // ƒ|ƒCƒ“ƒ^‚É‚µ‚ÄŠi”[
+      nntab.addPoint(&rlps[i]);              // ãƒã‚¤ãƒ³ã‚¿ã«ã—ã¦æ ¼ç´
   }
 
 /////////

--- a/hook/DataAssociatorLS.cpp
+++ b/hook/DataAssociatorLS.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,40 +17,40 @@
 
 using namespace std;
 
-// Œ»İƒXƒLƒƒƒ“curScan‚ÌŠeƒXƒLƒƒƒ““_‚É‘Î‰‚·‚é“_‚ğbaseLps‚©‚çŒ©‚Â‚¯‚é
+// ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³curScanã®å„ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã«å¯¾å¿œã™ã‚‹ç‚¹ã‚’baseLpsã‹ã‚‰è¦‹ã¤ã‘ã‚‹
 double DataAssociatorLS::findCorrespondence(const Scan2D *curScan, const Pose2D &predPose) {
-  boost::timer tim;                                 // ˆ—ŠÔ‘ª’è—p
+  boost::timer tim;                                 // å‡¦ç†æ™‚é–“æ¸¬å®šç”¨
 
-  double dthre = 0.2;                               // ‚±‚ê‚æ‚è‰“‚¢“_‚ÍœŠO‚·‚é[m]
-  curLps.clear();                                   // ‘Î‰‚Ã‚¯Œ»İƒXƒLƒƒƒ““_ŒQ‚ğ‹ó‚É‚·‚é
-  refLps.clear();                                   // ‘Î‰‚Ã‚¯QÆƒXƒLƒƒƒ““_ŒQ‚ğ‹ó‚É‚·‚é
+  double dthre = 0.2;                               // ã“ã‚Œã‚ˆã‚Šé ã„ç‚¹ã¯é™¤å¤–ã™ã‚‹[m]
+  curLps.clear();                                   // å¯¾å¿œã¥ã‘ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’ç©ºã«ã™ã‚‹
+  refLps.clear();                                   // å¯¾å¿œã¥ã‘å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’ç©ºã«ã™ã‚‹
   for (size_t i=0; i<curScan->lps.size(); i++) {
-    const LPoint2D *clp = &(curScan->lps[i]);       // Œ»İƒXƒLƒƒƒ“‚Ì“_Bƒ|ƒCƒ“ƒ^‚ÅB
+    const LPoint2D *clp = &(curScan->lps[i]);       // ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ã€‚ãƒã‚¤ãƒ³ã‚¿ã§ã€‚
 
-    // ƒXƒLƒƒƒ““_lp‚ğpredPose‚ÅÀ•W•ÏŠ·‚µ‚½ˆÊ’u‚ÉÅ‚à‹ß‚¢“_‚ğŒ©‚Â‚¯‚é
-    LPoint2D glp;                                   // clp‚Ì—\‘ªˆÊ’u
-    predPose.globalPoint(*clp, glp);                // predPose‚ÅÀ•W•ÏŠ·
+    // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹lpã‚’predPoseã§åº§æ¨™å¤‰æ›ã—ãŸä½ç½®ã«æœ€ã‚‚è¿‘ã„ç‚¹ã‚’è¦‹ã¤ã‘ã‚‹
+    LPoint2D glp;                                   // clpã®äºˆæ¸¬ä½ç½®
+    predPose.globalPoint(*clp, glp);                // predPoseã§åº§æ¨™å¤‰æ›
 
-    double dmin = HUGE_VAL;                         // ‹——£Å¬’l
-    const LPoint2D *rlpmin = nullptr;               // Å‚à‹ß‚¢“_
+    double dmin = HUGE_VAL;                         // è·é›¢æœ€å°å€¤
+    const LPoint2D *rlpmin = nullptr;               // æœ€ã‚‚è¿‘ã„ç‚¹
     for (size_t j=0; j<baseLps.size(); j++) {
-      const LPoint2D *rlp = baseLps[j];             // QÆƒXƒLƒƒƒ““_
+      const LPoint2D *rlp = baseLps[j];             // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ç‚¹
       double d = (glp.x - rlp->x)*(glp.x - rlp->x) + (glp.y - rlp->y)*(glp.y - rlp->y);
-      if (d <= dthre*dthre && d < dmin) {           // dthre“à‚Å‹——£‚ªÅ¬‚Æ‚È‚é“_‚ğ•Û‘¶
+      if (d <= dthre*dthre && d < dmin) {           // dthreå†…ã§è·é›¢ãŒæœ€å°ã¨ãªã‚‹ç‚¹ã‚’ä¿å­˜
         dmin = d;
         rlpmin = rlp;
       }
     }
-    if (rlpmin != nullptr) {                        // Å‹ß–T“_‚ª‚ ‚ê‚Î“o˜^
+    if (rlpmin != nullptr) {                        // æœ€è¿‘å‚ç‚¹ãŒã‚ã‚Œã°ç™»éŒ²
       curLps.push_back(clp);
       refLps.push_back(rlpmin);
     }
   }
   
-  double ratio = (1.0*curLps.size())/curScan->lps.size();         // ‘Î‰‚ª‚Æ‚ê‚½“_‚Ì”ä—¦
+  double ratio = (1.0*curLps.size())/curScan->lps.size();         // å¯¾å¿œãŒã¨ã‚ŒãŸç‚¹ã®æ¯”ç‡
 //  printf("ratio=%g, clps.size=%lu\n", ratio, curScan->lps.size());
 
-//  double t1 = 1000*tim.elapsed();                               // ˆ—ŠÔ
+//  double t1 = 1000*tim.elapsed();                               // å‡¦ç†æ™‚é–“
 //  printf("Elapsed time: dassLS=%g\n", t1);
 
   return(ratio);

--- a/hook/DataAssociatorLS.h
+++ b/hook/DataAssociatorLS.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,11 +17,11 @@
 
 #include "DataAssociator.h"
 
-// üŒ`’Tõ‚ğ—p‚¢‚ÄAŒ»İƒXƒLƒƒƒ“‚ÆQÆƒXƒLƒƒƒ“ŠÔ‚Ì“_‚Ì‘Î‰‚Ã‚¯‚ğs‚¤
+// ç·šå½¢æ¢ç´¢ã‚’ç”¨ã„ã¦ã€ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³ã¨å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³é–“ã®ç‚¹ã®å¯¾å¿œã¥ã‘ã‚’è¡Œã†
 class DataAssociatorLS : public DataAssociator
 {
 private:
-  std::vector<const LPoint2D*> baseLps;              // QÆƒXƒLƒƒƒ“‚Ì“_‚ğŠi”[‚µ‚Ä‚¨‚­Bì‹Æ—p
+  std::vector<const LPoint2D*> baseLps;              // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ã‚’æ ¼ç´ã—ã¦ãŠãã€‚ä½œæ¥­ç”¨
 
 public:
   DataAssociatorLS() {
@@ -30,11 +30,11 @@ public:
   ~DataAssociatorLS() {
   }
 
-  // QÆƒXƒLƒƒƒ“‚Ì“_rlps‚ğƒ|ƒCƒ“ƒ^‚É‚µ‚ÄbaseLps‚É“ü‚ê‚é
+  // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹rlpsã‚’ãƒã‚¤ãƒ³ã‚¿ã«ã—ã¦baseLpsã«å…¥ã‚Œã‚‹
   virtual void setRefBase(const std::vector<LPoint2D> &rlps) {
     baseLps.clear();
     for (size_t i=0; i<rlps.size(); i++)
-      baseLps.push_back(&rlps[i]);                // ƒ|ƒCƒ“ƒ^‚É‚µ‚ÄŠi”[
+      baseLps.push_back(&rlps[i]);                // ãƒã‚¤ãƒ³ã‚¿ã«ã—ã¦æ ¼ç´
   }
 
 /////////

--- a/hook/LoopDetectorSS.cpp
+++ b/hook/LoopDetectorSS.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,67 +18,67 @@ using namespace std;
 
 ////////////
 
-// ƒ‹[ƒvŒŸo
-// Œ»İˆÊ’ucurPose‚É‹ß‚­AŒ»İƒXƒLƒƒƒ“curScan‚ÉŒ`‚ªˆê’v‚·‚éêŠ‚ğƒƒ{ƒbƒg‹OÕ‚©‚çŒ©‚Â‚¯‚Äƒ|[ƒYƒA[ƒN‚ğ’£‚éB
+// ãƒ«ãƒ¼ãƒ—æ¤œå‡º
+// ç¾åœ¨ä½ç½®curPoseã«è¿‘ãã€ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³curScanã«å½¢ãŒä¸€è‡´ã™ã‚‹å ´æ‰€ã‚’ãƒ­ãƒœãƒƒãƒˆè»Œè·¡ã‹ã‚‰è¦‹ã¤ã‘ã¦ãƒãƒ¼ã‚ºã‚¢ãƒ¼ã‚¯ã‚’å¼µã‚‹ã€‚
 bool LoopDetectorSS::detectLoop(Scan2D *curScan, Pose2D &curPose, int cnt) {
   printf("-- detectLoop -- \n");
 
-  // Å‚à‹ß‚¢•”•ª’n}‚ğ’T‚·
-  double atd = pcmap->atd;                             // Œ»İ‚ÌÀÛ‚Ì—İÏ‘–s‹——£
-  double atdR = 0;                                     // ‰º‹L‚Ìˆ—‚Å‹OÕ‚ğ‚È‚¼‚é‚Ì—İÏ‘–s‹——£
-  const vector<Submap> &submaps = pcmap->submaps;      // •”•ª’n}
-  const vector<Pose2D> &poses = pcmap->poses;          // ƒƒ{ƒbƒg‹OÕ
-  double dmin=HUGE_VAL;                                // ‘O‰ñ–K–â“_‚Ü‚Å‚Ì‹——£‚ÌÅ¬’l
-  size_t imin=0, jmin=0;                               // ‹——£Å¬‚Ì‘O‰ñ–K–â“_‚ÌƒCƒ“ƒfƒbƒNƒX
-  Pose2D prevP;                                        // ’¼‘O‚Ìƒƒ{ƒbƒgˆÊ’u
-  for (size_t i=0; i<submaps.size()-1; i++) {          // Œ»İ‚Ì•”•ª’n}ˆÈŠO‚ğ’T‚·
-    const Submap &submap = submaps[i];                 // i”Ô–Ú‚Ì•”•ª’n}
-    for (size_t j=submap.cntS; j<=submap.cntE; j++) {  // •”•ª’n}‚ÌŠeƒƒ{ƒbƒgˆÊ’u‚É‚Â‚¢‚Ä
-      Pose2D p = poses[j];                             // ƒƒ{ƒbƒgˆÊ’u
+  // æœ€ã‚‚è¿‘ã„éƒ¨åˆ†åœ°å›³ã‚’æ¢ã™
+  double atd = pcmap->atd;                             // ç¾åœ¨ã®å®Ÿéš›ã®ç´¯ç©èµ°è¡Œè·é›¢
+  double atdR = 0;                                     // ä¸‹è¨˜ã®å‡¦ç†ã§è»Œè·¡ã‚’ãªãã‚‹æ™‚ã®ç´¯ç©èµ°è¡Œè·é›¢
+  const vector<Submap> &submaps = pcmap->submaps;      // éƒ¨åˆ†åœ°å›³
+  const vector<Pose2D> &poses = pcmap->poses;          // ãƒ­ãƒœãƒƒãƒˆè»Œè·¡
+  double dmin=HUGE_VAL;                                // å‰å›è¨ªå•ç‚¹ã¾ã§ã®è·é›¢ã®æœ€å°å€¤
+  size_t imin=0, jmin=0;                               // è·é›¢æœ€å°ã®å‰å›è¨ªå•ç‚¹ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+  Pose2D prevP;                                        // ç›´å‰ã®ãƒ­ãƒœãƒƒãƒˆä½ç½®
+  for (size_t i=0; i<submaps.size()-1; i++) {          // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³ä»¥å¤–ã‚’æ¢ã™
+    const Submap &submap = submaps[i];                 // iç•ªç›®ã®éƒ¨åˆ†åœ°å›³
+    for (size_t j=submap.cntS; j<=submap.cntE; j++) {  // éƒ¨åˆ†åœ°å›³ã®å„ãƒ­ãƒœãƒƒãƒˆä½ç½®ã«ã¤ã„ã¦
+      Pose2D p = poses[j];                             // ãƒ­ãƒœãƒƒãƒˆä½ç½®
       atdR += sqrt((p.tx - prevP.tx)*(p.tx - prevP.tx) + (p.ty - prevP.ty)*(p.ty - prevP.ty));
-      if (atd-atdR < atdthre) {                        // Œ»İˆÊ’u‚Ü‚Å‚Ì‘–s‹——£‚ª’Z‚¢‚Æƒ‹[ƒv‚Æ‚İ‚È‚³‚¸A‚à‚¤‚â‚ß‚é
-        i = submaps.size();                            // ‚±‚ê‚ÅŠO‘¤‚Ìƒ‹[ƒv‚©‚ç‚à”²‚¯‚é
+      if (atd-atdR < atdthre) {                        // ç¾åœ¨ä½ç½®ã¾ã§ã®èµ°è¡Œè·é›¢ãŒçŸ­ã„ã¨ãƒ«ãƒ¼ãƒ—ã¨ã¿ãªã•ãšã€ã‚‚ã†ã‚„ã‚ã‚‹
+        i = submaps.size();                            // ã“ã‚Œã§å¤–å´ã®ãƒ«ãƒ¼ãƒ—ã‹ã‚‰ã‚‚æŠœã‘ã‚‹
         break;
       }
       prevP = p;
 
       double d = (curPose.tx - p.tx)*(curPose.tx - p.tx) + (curPose.ty - p.ty)*(curPose.ty - p.ty);
-      if (d < dmin) {                                  // Œ»İˆÊ’u‚Æp‚Æ‚Ì‹——£‚ª‚±‚ê‚Ü‚Å‚ÌÅ¬‚©
+      if (d < dmin) {                                  // ç¾åœ¨ä½ç½®ã¨pã¨ã®è·é›¢ãŒã“ã‚Œã¾ã§ã®æœ€å°ã‹
         dmin = d;
-        imin = i;                                      // Œó•â‚Æ‚È‚é•”•ª’n}‚ÌƒCƒ“ƒfƒbƒNƒX
-        jmin = j;                                      // ‘O‰ñ–K–â“_‚ÌƒCƒ“ƒfƒbƒNƒX
+        imin = i;                                      // å€™è£œã¨ãªã‚‹éƒ¨åˆ†åœ°å›³ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
+        jmin = j;                                      // å‰å›è¨ªå•ç‚¹ã®ã‚¤ãƒ³ãƒ‡ãƒƒã‚¯ã‚¹
       }
-//      printf("i=%lu, j=%lu: atd=%g, atdR=%g, atdthre=%g\n", i, j, atd, atdR, atdthre);             // Šm”F—p
+//      printf("i=%lu, j=%lu: atd=%g, atdR=%g, atdthre=%g\n", i, j, atd, atdR, atdthre);             // ç¢ºèªç”¨
     }
   }
 
-  printf("dmin=%g, radius=%g, imin=%lu, jmin=%lu\n", sqrt(dmin), radius, imin, jmin);  // Šm”F—p
+  printf("dmin=%g, radius=%g, imin=%lu, jmin=%lu\n", sqrt(dmin), radius, imin, jmin);  // ç¢ºèªç”¨
 
-  if (dmin > radius*radius)                            // ‘O‰ñ–K–â“_‚Ü‚Å‚Ì‹——£‚ª‰“‚¢‚Æƒ‹[ƒvŒŸo‚µ‚È‚¢
+  if (dmin > radius*radius)                            // å‰å›è¨ªå•ç‚¹ã¾ã§ã®è·é›¢ãŒé ã„ã¨ãƒ«ãƒ¼ãƒ—æ¤œå‡ºã—ãªã„
     return(false);
 
-  Submap &refSubmap = pcmap->submaps[imin];            // Å‚à‹ß‚¢•”•ª’n}‚ğQÆƒXƒLƒƒƒ“‚É‚·‚é
+  Submap &refSubmap = pcmap->submaps[imin];            // æœ€ã‚‚è¿‘ã„éƒ¨åˆ†åœ°å›³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã«ã™ã‚‹
   const Pose2D &initPose = poses[jmin];
   printf("curPose:  tx=%g, ty=%g, th=%g\n", curPose.tx, curPose.ty, curPose.th);
   printf("initPose: tx=%g, ty=%g, th=%g\n", initPose.tx, initPose.ty, initPose.th);
 
-  // Ä–K“_‚ÌˆÊ’u‚ğ‹‚ß‚é
+  // å†è¨ªç‚¹ã®ä½ç½®ã‚’æ±‚ã‚ã‚‹
   Pose2D revisitPose;
   bool flag = estimateRevisitPose(curScan, refSubmap.mps, curPose, revisitPose);
 //  bool flag = estimateRelativePose(curScan, refSubmap.mps, initPose, revisitPose);
 
-  if (flag) {                                          // ƒ‹[ƒv‚ğŒŸo‚µ‚½
-    Eigen::Matrix3d icpCov;                                                  // ICP‚Ì‹¤•ªU
-    double ratio = pfu->calIcpCovariance(revisitPose, curScan, icpCov);      // ICP‚Ì‹¤•ªU‚ğŒvZ
+  if (flag) {                                          // ãƒ«ãƒ¼ãƒ—ã‚’æ¤œå‡ºã—ãŸ
+    Eigen::Matrix3d icpCov;                                                  // ICPã®å…±åˆ†æ•£
+    double ratio = pfu->calIcpCovariance(revisitPose, curScan, icpCov);      // ICPã®å…±åˆ†æ•£ã‚’è¨ˆç®—
 
-    LoopInfo info;                                     // ƒ‹[ƒvŒŸoŒ‹‰Ê
-    info.pose = revisitPose;                           // ƒ‹[ƒvƒA[ƒNî•ñ‚ÉÄ–K“_ˆÊ’u‚ğİ’è
-    info.cov = icpCov;                                 // ƒ‹[ƒvƒA[ƒNî•ñ‚É‹¤•ªU‚ğİ’èB
-    info.curId = cnt;                                  // Œ»İˆÊ’u‚Ìƒm[ƒhid
-    info.refId = static_cast<int>(jmin);               // ‘O‰ñ–K–â“_‚Ìƒm[ƒhid
-    makeLoopArc(info);                                 // ƒ‹[ƒvƒA[ƒN¶¬
+    LoopInfo info;                                     // ãƒ«ãƒ¼ãƒ—æ¤œå‡ºçµæœ
+    info.pose = revisitPose;                           // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯æƒ…å ±ã«å†è¨ªç‚¹ä½ç½®ã‚’è¨­å®š
+    info.cov = icpCov;                                 // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯æƒ…å ±ã«å…±åˆ†æ•£ã‚’è¨­å®šã€‚
+    info.curId = cnt;                                  // ç¾åœ¨ä½ç½®ã®ãƒãƒ¼ãƒ‰id
+    info.refId = static_cast<int>(jmin);               // å‰å›è¨ªå•ç‚¹ã®ãƒãƒ¼ãƒ‰id
+    makeLoopArc(info);                                 // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ç”Ÿæˆ
 
-    // Šm”F—p
+    // ç¢ºèªç”¨
     Scan2D refScan;
     Pose2D spose = poses[refSubmap.cntS];
     refScan.setSid(info.refId);
@@ -94,25 +94,25 @@ bool LoopDetectorSS::detectLoop(Scan2D *curScan, Pose2D &curPose, int cnt) {
 
 //////////
 
-// ‘O‰ñ–K–â“_(refId)‚ğn“_ƒm[ƒhAŒ»İˆÊ’u(curId)‚ğI“_ƒm[ƒh‚É‚µ‚ÄAƒ‹[ƒvƒA[ƒN‚ğ¶¬‚·‚éB
+// å‰å›è¨ªå•ç‚¹(refId)ã‚’å§‹ç‚¹ãƒãƒ¼ãƒ‰ã€ç¾åœ¨ä½ç½®(curId)ã‚’çµ‚ç‚¹ãƒãƒ¼ãƒ‰ã«ã—ã¦ã€ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ã‚’ç”Ÿæˆã™ã‚‹ã€‚
 void LoopDetectorSS::makeLoopArc(LoopInfo &info) {
-  if (info.arcked)                                             // info‚ÌƒA[ƒN‚Í‚·‚Å‚É’£‚Á‚Ä‚ ‚é
+  if (info.arcked)                                             // infoã®ã‚¢ãƒ¼ã‚¯ã¯ã™ã§ã«å¼µã£ã¦ã‚ã‚‹
     return;
   info.setArcked(true);
 
-  Pose2D srcPose = pcmap->poses[info.refId];                   // ‘O‰ñ–K–â“_‚ÌˆÊ’u
-  Pose2D dstPose(info.pose.tx, info.pose.ty, info.pose.th);    // Ä–K“_‚ÌˆÊ’u
+  Pose2D srcPose = pcmap->poses[info.refId];                   // å‰å›è¨ªå•ç‚¹ã®ä½ç½®
+  Pose2D dstPose(info.pose.tx, info.pose.ty, info.pose.th);    // å†è¨ªç‚¹ã®ä½ç½®
   Pose2D relPose;
-  Pose2D::calRelativePose(dstPose, srcPose, relPose);          // ƒ‹[ƒvƒA[ƒN‚ÌS‘©
+  Pose2D::calRelativePose(dstPose, srcPose, relPose);          // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ã®æ‹˜æŸ
 
-  // ƒA[ƒN‚ÌS‘©‚Ín“_ƒm[ƒh‚©‚ç‚Ì‘Š‘ÎˆÊ’u‚È‚Ì‚ÅA‹¤•ªU‚ğƒ‹[ƒvƒA[ƒN‚Ìn“_ƒm[ƒhÀ•WŒn‚É•ÏŠ·
+  // ã‚¢ãƒ¼ã‚¯ã®æ‹˜æŸã¯å§‹ç‚¹ãƒãƒ¼ãƒ‰ã‹ã‚‰ã®ç›¸å¯¾ä½ç½®ãªã®ã§ã€å…±åˆ†æ•£ã‚’ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ã®å§‹ç‚¹ãƒãƒ¼ãƒ‰åº§æ¨™ç³»ã«å¤‰æ›
   Eigen::Matrix3d cov;
-  CovarianceCalculator::rotateCovariance(srcPose, info.cov, cov, true);    // ‹¤•ªU‚Ì‹t‰ñ“]
+  CovarianceCalculator::rotateCovariance(srcPose, info.cov, cov, true);    // å…±åˆ†æ•£ã®é€†å›è»¢
 
-  PoseArc *arc = pg->makeArc(info.refId, info.curId, relPose, cov);        // ƒ‹[ƒvƒA[ƒN¶¬
-  pg->addArc(arc);                                                         // ƒ‹[ƒvƒA[ƒN“o˜^
+  PoseArc *arc = pg->makeArc(info.refId, info.curId, relPose, cov);        // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ç”Ÿæˆ
+  pg->addArc(arc);                                                         // ãƒ«ãƒ¼ãƒ—ã‚¢ãƒ¼ã‚¯ç™»éŒ²
 
-  // Šm”F—p
+  // ç¢ºèªç”¨
   printf("makeLoopArc: pose arc added\n");
   printf("srcPose: tx=%g, ty=%g, th=%g\n", srcPose.tx, srcPose.ty, srcPose.th);
   printf("dstPose: tx=%g, ty=%g, th=%g\n", dstPose.tx, dstPose.ty, dstPose.th);
@@ -126,77 +126,77 @@ void LoopDetectorSS::makeLoopArc(LoopInfo &info) {
 
 //////////
 
-// Œ»İƒXƒLƒƒƒ“curScan‚Æ•”•ª’n}‚Ì“_ŒQrefLps‚ÅICP‚ğs‚¢AÄ–K“_‚ÌˆÊ’u‚ğ‹‚ß‚éB
+// ç¾åœ¨ã‚¹ã‚­ãƒ£ãƒ³curScanã¨éƒ¨åˆ†åœ°å›³ã®ç‚¹ç¾¤refLpsã§ICPã‚’è¡Œã„ã€å†è¨ªç‚¹ã®ä½ç½®ã‚’æ±‚ã‚ã‚‹ã€‚
 bool LoopDetectorSS::estimateRevisitPose(const Scan2D *curScan, const vector<LPoint2D> &refLps, const Pose2D &initPose, Pose2D &revisitPose) {
-  dass->setRefBase(refLps);                              // ƒf[ƒ^‘Î‰‚Ã‚¯Ší‚ÉQÆ“_ŒQ‚ğİ’è
-  cfunc->setEvlimit(0.2);                                // ƒRƒXƒgŠÖ”‚ÌŒë·è‡’l
+  dass->setRefBase(refLps);                              // ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘å™¨ã«å‚ç…§ç‚¹ç¾¤ã‚’è¨­å®š
+  cfunc->setEvlimit(0.2);                                // ã‚³ã‚¹ãƒˆé–¢æ•°ã®èª¤å·®é–¾å€¤
 
-  printf("initPose: tx=%g, ty=%g, th=%g\n", initPose.tx, initPose.ty, initPose.th);       // Šm”F—p
+  printf("initPose: tx=%g, ty=%g, th=%g\n", initPose.tx, initPose.ty, initPose.th);       // ç¢ºèªç”¨
 
   size_t usedNumMin = 50; 
 //  size_t usedNumMin = 100;
 
-  // ‰ŠúˆÊ’uinitPose‚ÌüˆÍ‚ğ‚µ‚ç‚İ‚Â‚Ô‚µ‚É’²‚×‚éB
-  // Œø—¦‰»‚Ì‚½‚ßAICP‚Ís‚í‚¸AŠeˆÊ’u‚Å’Pƒ‚Éƒ}ƒbƒ`ƒ“ƒOƒXƒRƒA‚ğ’²‚×‚éB
-  double rangeT = 1;                                     // •Ài‚Ì’Tõ”ÍˆÍ[m]
-  double rangeA = 45;                                    // ‰ñ“]‚Ì’Tõ”ÍˆÍ[“x]
-  double dd = 0.2;                                       // •Ài‚Ì’TõŠÔŠu[m]
-  double da = 2;                                         // ‰ñ“]‚Ì’TõŠÔŠu[“x]
+  // åˆæœŸä½ç½®initPoseã®å‘¨å›²ã‚’ã—ã‚‰ã¿ã¤ã¶ã—ã«èª¿ã¹ã‚‹ã€‚
+  // åŠ¹ç‡åŒ–ã®ãŸã‚ã€ICPã¯è¡Œã‚ãšã€å„ä½ç½®ã§å˜ç´”ã«ãƒãƒƒãƒãƒ³ã‚°ã‚¹ã‚³ã‚¢ã‚’èª¿ã¹ã‚‹ã€‚
+  double rangeT = 1;                                     // ä¸¦é€²ã®æ¢ç´¢ç¯„å›²[m]
+  double rangeA = 45;                                    // å›è»¢ã®æ¢ç´¢ç¯„å›²[åº¦]
+  double dd = 0.2;                                       // ä¸¦é€²ã®æ¢ç´¢é–“éš”[m]
+  double da = 2;                                         // å›è»¢ã®æ¢ç´¢é–“éš”[åº¦]
   double pnrateMax=0;
   vector<double> pnrates;
   double scoreMin=1000;
   vector<double> scores;
-  vector<Pose2D> candidates;                             // ƒXƒRƒA‚Ì‚æ‚¢Œó•âˆÊ’u
-  for (double dy=-rangeT; dy<=rangeT; dy+=dd) {          // •Àiy‚Ì’TõŒJ‚è•Ô‚µ
-    double y = initPose.ty + dy;                         // ‰ŠúˆÊ’u‚É•ÏˆÊ•ªdy‚ğ‰Á‚¦‚é
-    for (double dx=-rangeT; dx<=rangeT; dx+=dd) {        // •Àix‚Ì’TõŒJ‚è•Ô‚µ
-      double x = initPose.tx + dx;                       // ‰ŠúˆÊ’u‚É•ÏˆÊ•ªdx‚ğ‰Á‚¦‚é
-      for (double dth=-rangeA; dth<=rangeA; dth+=da) {   // ‰ñ“]‚Ì’TõŒJ‚è•Ô‚µ
-        double th = MyUtil::add(initPose.th, dth);       // ‰ŠúˆÊ’u‚É•ÏˆÊ•ªdth‚ğ‰Á‚¦‚é
+  vector<Pose2D> candidates;                             // ã‚¹ã‚³ã‚¢ã®ã‚ˆã„å€™è£œä½ç½®
+  for (double dy=-rangeT; dy<=rangeT; dy+=dd) {          // ä¸¦é€²yã®æ¢ç´¢ç¹°ã‚Šè¿”ã—
+    double y = initPose.ty + dy;                         // åˆæœŸä½ç½®ã«å¤‰ä½åˆ†dyã‚’åŠ ãˆã‚‹
+    for (double dx=-rangeT; dx<=rangeT; dx+=dd) {        // ä¸¦é€²xã®æ¢ç´¢ç¹°ã‚Šè¿”ã—
+      double x = initPose.tx + dx;                       // åˆæœŸä½ç½®ã«å¤‰ä½åˆ†dxã‚’åŠ ãˆã‚‹
+      for (double dth=-rangeA; dth<=rangeA; dth+=da) {   // å›è»¢ã®æ¢ç´¢ç¹°ã‚Šè¿”ã—
+        double th = MyUtil::add(initPose.th, dth);       // åˆæœŸä½ç½®ã«å¤‰ä½åˆ†dthã‚’åŠ ãˆã‚‹
         Pose2D pose(x, y, th);
-        double mratio = dass->findCorrespondence(curScan, pose);   // ˆÊ’upose‚Åƒf[ƒ^‘Î‰‚Ã‚¯
+        double mratio = dass->findCorrespondence(curScan, pose);   // ä½ç½®poseã§ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘
         size_t usedNum = dass->curLps.size();
-//        printf("usedNum=%lu, mratio=%g\n", usedNum, mratio);          // Šm”F—p
-        if (usedNum < usedNumMin || mratio < 0.9)        // ‘Î‰—¦‚ªˆ«‚¢‚Æ”ò‚Î‚·
+//        printf("usedNum=%lu, mratio=%g\n", usedNum, mratio);          // ç¢ºèªç”¨
+        if (usedNum < usedNumMin || mratio < 0.9)        // å¯¾å¿œç‡ãŒæ‚ªã„ã¨é£›ã°ã™
           continue;
-        cfunc->setPoints(dass->curLps, dass->refLps);    // ƒRƒXƒgŠÖ”‚É“_ŒQ‚ğİ’è
-        double score =  cfunc->calValue(x, y, th);       // ƒRƒXƒg’liƒ}ƒbƒ`ƒ“ƒOƒXƒRƒAj
-        double pnrate = cfunc->getPnrate();              // Ú×‚È“_‚Ì‘Î‰—¦
-//        printf("score=%g, pnrate=%g\n", score, pnrate);                    // Šm”F—p
+        cfunc->setPoints(dass->curLps, dass->refLps);    // ã‚³ã‚¹ãƒˆé–¢æ•°ã«ç‚¹ç¾¤ã‚’è¨­å®š
+        double score =  cfunc->calValue(x, y, th);       // ã‚³ã‚¹ãƒˆå€¤ï¼ˆãƒãƒƒãƒãƒ³ã‚°ã‚¹ã‚³ã‚¢ï¼‰
+        double pnrate = cfunc->getPnrate();              // è©³ç´°ãªç‚¹ã®å¯¾å¿œç‡
+//        printf("score=%g, pnrate=%g\n", score, pnrate);                    // ç¢ºèªç”¨
         if (pnrate > 0.8) {
           candidates.emplace_back(pose);
           if (score < scoreMin)
             scoreMin = score;
           scores.push_back(score);
-//          printf("pose: tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);  // Šm”F—p
-//          printf("score=%g, pnrate=%g\n", score, pnrate);                    // Šm”F—p
+//          printf("pose: tx=%g, ty=%g, th=%g\n", pose.tx, pose.ty, pose.th);  // ç¢ºèªç”¨
+//          printf("score=%g, pnrate=%g\n", score, pnrate);                    // ç¢ºèªç”¨
         }
       }
     }
   }
-  printf("candidates.size=%lu\n", candidates.size());                           // Šm”F—p
+  printf("candidates.size=%lu\n", candidates.size());                           // ç¢ºèªç”¨
   if (candidates.size() == 0)
     return(false);
 
-  // Œó•âˆÊ’ucandidates‚Ì’†‚©‚çÅ‚à‚æ‚¢‚à‚Ì‚ğICP‚Å‘I‚Ô
-  Pose2D best;                                              // Å—ÇŒó•â
-  double smin=1000000;                                      // ICPƒXƒRƒAÅ¬’l
-  estim->setScanPair(curScan, refLps);                      // ICP‚ÉƒXƒLƒƒƒ“İ’è
+  // å€™è£œä½ç½®candidatesã®ä¸­ã‹ã‚‰æœ€ã‚‚ã‚ˆã„ã‚‚ã®ã‚’ICPã§é¸ã¶
+  Pose2D best;                                              // æœ€è‰¯å€™è£œ
+  double smin=1000000;                                      // ICPã‚¹ã‚³ã‚¢æœ€å°å€¤
+  estim->setScanPair(curScan, refLps);                      // ICPã«ã‚¹ã‚­ãƒ£ãƒ³è¨­å®š
   for (size_t i=0; i<candidates.size(); i++) {
-    Pose2D p = candidates[i];                               // Œó•âˆÊ’u
-    printf("score=%g\n", scores[i]);    // Šm”F—p
+    Pose2D p = candidates[i];                               // å€™è£œä½ç½®
+    printf("score=%g\n", scores[i]);    // ç¢ºèªç”¨
     Pose2D estP;
-    double score = estim->estimatePose(p, estP);            // ICP‚Åƒ}ƒbƒ`ƒ“ƒOˆÊ’u‚ğ‹‚ß‚é
-    double pnrate = estim->getPnrate();                     // ICP‚Å‚Ì“_‚Ì‘Î‰—¦
-    size_t usedNum = estim->getUsedNum();                   // ICP‚Åg—p‚µ‚½“_”
-    if (score < smin && pnrate >= 0.9 && usedNum >= usedNumMin) {  // ƒ‹[ƒvŒŸo‚ÍğŒŒµ‚µ‚­
+    double score = estim->estimatePose(p, estP);            // ICPã§ãƒãƒƒãƒãƒ³ã‚°ä½ç½®ã‚’æ±‚ã‚ã‚‹
+    double pnrate = estim->getPnrate();                     // ICPã§ã®ç‚¹ã®å¯¾å¿œç‡
+    size_t usedNum = estim->getUsedNum();                   // ICPã§ä½¿ç”¨ã—ãŸç‚¹æ•°
+    if (score < smin && pnrate >= 0.9 && usedNum >= usedNumMin) {  // ãƒ«ãƒ¼ãƒ—æ¤œå‡ºã¯æ¡ä»¶å³ã—ã
       smin = score;
       best = estP;
-      printf("smin=%g, pnrate=%g, usedNum=%lu\n", smin, pnrate, usedNum);    // Šm”F—p
+      printf("smin=%g, pnrate=%g, usedNum=%lu\n", smin, pnrate, usedNum);    // ç¢ºèªç”¨
     }
   }
 
-  // Å¬ƒXƒRƒA‚ªè‡’l‚æ‚è¬‚³‚¯‚ê‚ÎŒ©‚Â‚¯‚½
+  // æœ€å°ã‚¹ã‚³ã‚¢ãŒé–¾å€¤ã‚ˆã‚Šå°ã•ã‘ã‚Œã°è¦‹ã¤ã‘ãŸ
   if (smin <= scthre) {
     revisitPose = best;
     return(true);

--- a/hook/LoopDetectorSS.h
+++ b/hook/LoopDetectorSS.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -27,15 +27,15 @@
 class LoopDetectorSS : public LoopDetector
 {
 private:
-  double radius;                               // ’Tõ”¼Œa[m]iŒ»İˆÊ’u‚ÆÄ–K“_‚Ì‹——£è‡’lj
-  double atdthre;                              // —İÏ‘–s‹——£‚Ì·‚Ìè‡’l[m]
-  double scthre;                               // ICPƒXƒRƒA‚Ìè‡’l
+  double radius;                               // æ¢ç´¢åŠå¾„[m]ï¼ˆç¾åœ¨ä½ç½®ã¨å†è¨ªç‚¹ã®è·é›¢é–¾å€¤ï¼‰
+  double atdthre;                              // ç´¯ç©èµ°è¡Œè·é›¢ã®å·®ã®é–¾å€¤[m]
+  double scthre;                               // ICPã‚¹ã‚³ã‚¢ã®é–¾å€¤
 
-  PointCloudMapLP *pcmap;                      // “_ŒQ’n}
-  CostFunction *cfunc;                         // ƒRƒXƒgŠÖ”(ICP‚Æ‚Í•Ê‚Ég‚¤)
-  PoseEstimatorICP *estim;                     // ƒƒ{ƒbƒgˆÊ’u„’èŠí(ICP)
-  DataAssociator *dass;                        // ƒf[ƒ^‘Î‰‚Ã‚¯Ší
-  PoseFuser *pfu;                              // ƒZƒ“ƒT—Z‡Ší
+  PointCloudMapLP *pcmap;                      // ç‚¹ç¾¤åœ°å›³
+  CostFunction *cfunc;                         // ã‚³ã‚¹ãƒˆé–¢æ•°(ICPã¨ã¯åˆ¥ã«ä½¿ã†)
+  PoseEstimatorICP *estim;                     // ãƒ­ãƒœãƒƒãƒˆä½ç½®æ¨å®šå™¨(ICP)
+  DataAssociator *dass;                        // ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘å™¨
+  PoseFuser *pfu;                              // ã‚»ãƒ³ã‚µèåˆå™¨
 
 public:
   LoopDetectorSS() : radius(4), atdthre(10), scthre(0.2) {

--- a/hook/PointCloudMapBS.cpp
+++ b/hook/PointCloudMapBS.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,32 +18,32 @@ using namespace std;
 
 ///////////
 
-// ƒƒ{ƒbƒgˆÊ’u‚Ì’Ç‰Á
+// ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®è¿½åŠ 
 void PointCloudMapBS::addPose(const Pose2D &p) {
   poses.emplace_back(p);
 }
 
-// ƒXƒLƒƒƒ““_ŒQ‚Ì’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã®è¿½åŠ 
 void PointCloudMapBS::addPoints(const vector<LPoint2D> &lps) {
-  int skip=5;                                       // ‚³‚·‚ª‚Éd‚¢‚Ì‚ÅA1/5‚ÉŠÔˆø‚­
-//  int skip=10;                                       // ‚³‚·‚ª‚Éd‚¢‚Ì‚ÅA1/10‚ÉŠÔˆø‚­
+  int skip=5;                                       // ã•ã™ãŒã«é‡ã„ã®ã§ã€1/5ã«é–“å¼•ã
+//  int skip=10;                                       // ã•ã™ãŒã«é‡ã„ã®ã§ã€1/10ã«é–“å¼•ã
   for (size_t i=0; i<lps.size(); i+=skip) {
-    globalMap.emplace_back(lps[i]);                 // ‘S‘Ì’n}‚É’Ç‰Á‚·‚é‚¾‚¯
+    globalMap.emplace_back(lps[i]);                 // å…¨ä½“åœ°å›³ã«è¿½åŠ ã™ã‚‹ã ã‘
   }
 }
 
-// ‘S‘Ì’n}¶¬B‚·‚Å‚É‚Å‚«‚Ä‚¢‚é‚Ì‚Å‰½‚à‚µ‚È‚¢
+// å…¨ä½“åœ°å›³ç”Ÿæˆã€‚ã™ã§ã«ã§ãã¦ã„ã‚‹ã®ã§ä½•ã‚‚ã—ãªã„
 void PointCloudMapBS::makeGlobalMap(){
-  printf("globalMap.size=%lu\n", globalMap.size());   // Šm”F—p
+  printf("globalMap.size=%lu\n", globalMap.size());   // ç¢ºèªç”¨
 }
 
-// ‹ÇŠ’n}¶¬Bƒ_ƒ~[
+// å±€æ‰€åœ°å›³ç”Ÿæˆã€‚ãƒ€ãƒŸãƒ¼
 void PointCloudMapBS::makeLocalMap(){
 //  localMap = globalMap;
 }
 
 ////////
 
-// ƒ_ƒ~[
+// ãƒ€ãƒŸãƒ¼
 void PointCloudMapBS::remakeMaps(const vector<Pose2D> &newPoses) {
 }

--- a/hook/PointCloudMapBS.h
+++ b/hook/PointCloudMapBS.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,7 +17,7 @@
 
 #include "PointCloudMap.h"
 
-// ƒXƒLƒƒƒ““_‚ğ‚·‚×‚Ä•Û‘¶‚·‚é“_ŒQ’n}
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã‚’ã™ã¹ã¦ä¿å­˜ã™ã‚‹ç‚¹ç¾¤åœ°å›³
 class PointCloudMapBS : public PointCloudMap
 {
 public:

--- a/hook/PointCloudMapGT.cpp
+++ b/hook/PointCloudMapGT.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,39 +18,39 @@ using namespace std;
 
 ///////////
 
-// ƒƒ{ƒbƒgˆÊ’u‚Ì’Ç‰Á
+// ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®è¿½åŠ 
 void PointCloudMapGT::addPose(const Pose2D &p) {
   poses.emplace_back(p);
 }
 
-// Šiqƒe[ƒuƒ‹‚ÌŠeƒZƒ‹‚Ì‘ã•\“_‚ğ‹‚ß‚Äsps‚ÉŠi”[‚·‚é
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã®å„ã‚»ãƒ«ã®ä»£è¡¨ç‚¹ã‚’æ±‚ã‚ã¦spsã«æ ¼ç´ã™ã‚‹
 void PointCloudMapGT::subsamplePoints(vector<LPoint2D> &sps) {
-  nntab.clear();                            // Šiqƒe[ƒuƒ‹‚Ì‰Šú‰»
+  nntab.clear();                            // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã®åˆæœŸåŒ–
   for (size_t i=0; i<allLps.size(); i++) 
-    nntab.addPoint(&(allLps[i]));           // ‘S“_‚ğŠiqƒe[ƒuƒ‹‚É“o˜^
+    nntab.addPoint(&(allLps[i]));           // å…¨ç‚¹ã‚’æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã«ç™»éŒ²
 
-  nntab.makeCellPoints(nthre, sps);         // nthre“_ˆÈã‚ ‚éƒZƒ‹‚©‚ç‘ã•\“_‚ğ“¾‚é
+  nntab.makeCellPoints(nthre, sps);         // nthreç‚¹ä»¥ä¸Šã‚ã‚‹ã‚»ãƒ«ã‹ã‚‰ä»£è¡¨ç‚¹ã‚’å¾—ã‚‹
 
-  printf("allLps.size=%lu, sps.size=%lu\n", allLps.size(), sps.size());  // Šm”F—p
+  printf("allLps.size=%lu, sps.size=%lu\n", allLps.size(), sps.size());  // ç¢ºèªç”¨
 }
 
 /////////
 
-// ƒXƒLƒƒƒ““_ŒQ‚ğ’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã‚’è¿½åŠ 
 void PointCloudMapGT::addPoints(const vector<LPoint2D> &lps) {
   for (size_t i=0; i<lps.size(); i++)
     allLps.emplace_back(lps[i]);
 }
 
-// ‘S‘Ì’n}‚Ì¶¬
+// å…¨ä½“åœ°å›³ã®ç”Ÿæˆ
 void PointCloudMapGT::makeGlobalMap(){
   globalMap.clear();
-  subsamplePoints(globalMap);         // Šiqƒe[ƒuƒ‹‚ÌŠeƒZƒ‹‚Ì‘ã•\“_‚©‚ç‘S‘Ì’n}‚ğì‚é
+  subsamplePoints(globalMap);         // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã®å„ã‚»ãƒ«ã®ä»£è¡¨ç‚¹ã‹ã‚‰å…¨ä½“åœ°å›³ã‚’ä½œã‚‹
 
-  printf("GT: globalMap.size=%lu\n", globalMap.size());    // Šm”F—p
+  printf("GT: globalMap.size=%lu\n", globalMap.size());    // ç¢ºèªç”¨
 }
 
-// ‹ÇŠ’n}‚Ì¶¬B‘S‘Ì’n}‚ğ‚»‚Ì‚Ü‚Üg‚¤
+// å±€æ‰€åœ°å›³ã®ç”Ÿæˆã€‚å…¨ä½“åœ°å›³ã‚’ãã®ã¾ã¾ä½¿ã†
 void PointCloudMapGT::makeLocalMap(){
   localMap = globalMap;
   printf("GT: localMap.size=%lu\n", localMap.size());
@@ -58,6 +58,6 @@ void PointCloudMapGT::makeLocalMap(){
 
 ////////
 
-// ƒ_ƒ~[
+// ãƒ€ãƒŸãƒ¼
 void PointCloudMapGT::remakeMaps(const vector<Pose2D> &newPoses) {
 }

--- a/hook/PointCloudMapGT.h
+++ b/hook/PointCloudMapGT.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -21,16 +21,16 @@
 
 ///////////
 
-// Šiqƒe[ƒuƒ‹‚ğ—p‚¢‚½“_ŒQ’n}
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã‚’ç”¨ã„ãŸç‚¹ç¾¤åœ°å›³
 class PointCloudMapGT : public PointCloudMap
 {
 public:
-  std::vector<LPoint2D> allLps;             // ‘SƒXƒLƒƒƒ““_ŒQ
-  NNGridTable nntab;                        // Šiqƒe[ƒuƒ‹
+  std::vector<LPoint2D> allLps;             // å…¨ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
+  NNGridTable nntab;                        // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«
 
 public:
   PointCloudMapGT() {
-    allLps.reserve(MAX_POINT_NUM);          // Å‰‚ÉŠm•Û
+    allLps.reserve(MAX_POINT_NUM);          // æœ€åˆã«ç¢ºä¿
   }
 
   ~PointCloudMapGT() {

--- a/hook/PointCloudMapLP.cpp
+++ b/hook/PointCloudMapLP.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -21,16 +21,16 @@ double PointCloudMapLP::atdThre = 10;
 
 ///////////
 
-// Šiqƒe[ƒuƒ‹‚ğ—p‚¢‚ÄA•”•ª’n}‚Ì‘ã•\“_‚ğ“¾‚é
+// æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«ã‚’ç”¨ã„ã¦ã€éƒ¨åˆ†åœ°å›³ã®ä»£è¡¨ç‚¹ã‚’å¾—ã‚‹
 vector<LPoint2D> Submap::subsamplePoints(int nthre) {
-  NNGridTable nntab;                     // Šiqƒe[ƒuƒ‹
+  NNGridTable nntab;                     // æ ¼å­ãƒ†ãƒ¼ãƒ–ãƒ«
   for (size_t i=0; i<mps.size(); i++) {
     LPoint2D &lp = mps[i];
-    nntab.addPoint(&lp);                 // ‘S“_‚ğ“o˜^
+    nntab.addPoint(&lp);                 // å…¨ç‚¹ã‚’ç™»éŒ²
   }
 
   vector<LPoint2D> sps;
-  nntab.makeCellPoints(nthre, sps);      // nthreŒÂˆÈã‚ÌƒZƒ‹‚Ì‘ã•\“_‚ğsps‚É“ü‚ê‚é
+  nntab.makeCellPoints(nthre, sps);      // nthreå€‹ä»¥ä¸Šã®ã‚»ãƒ«ã®ä»£è¡¨ç‚¹ã‚’spsã«å…¥ã‚Œã‚‹
   printf("mps.size=%lu, sps.size=%lu\n", mps.size(), sps.size());
 
   return(sps);
@@ -38,9 +38,9 @@ vector<LPoint2D> Submap::subsamplePoints(int nthre) {
 
 /////////
 
-// ƒƒ{ƒbƒgˆÊ’u‚Ì’Ç‰Á
+// ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®è¿½åŠ 
 void PointCloudMapLP::addPose(const Pose2D &p) {
-  // —İÏ‘–s‹——£(atd)‚ÌŒvZ
+  // ç´¯ç©èµ°è¡Œè·é›¢(atd)ã®è¨ˆç®—
   if (poses.size() > 0) {
     Pose2D pp = poses.back();
     atd += sqrt((p.tx - pp.tx)*(p.tx - pp.tx) + (p.ty - pp.ty)*(p.ty - pp.ty));
@@ -52,109 +52,109 @@ void PointCloudMapLP::addPose(const Pose2D &p) {
   poses.emplace_back(p);
 }
 
-// ƒXƒLƒƒƒ““_‚Ì’Ç‰Á
+// ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ã®è¿½åŠ 
 void PointCloudMapLP::addPoints(const vector<LPoint2D> &lps) {
-  Submap &curSubmap = submaps.back();              // Œ»İ‚Ì•”•ª’n}
-  if (atd - curSubmap.atdS >= atdThre ) {          // —İÏ‘–s‹——£‚ªè‡’l‚ğ’´‚¦‚½‚çV‚µ‚¢•”•ª’n}‚É•Ï‚¦‚é
+  Submap &curSubmap = submaps.back();              // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³
+  if (atd - curSubmap.atdS >= atdThre ) {          // ç´¯ç©èµ°è¡Œè·é›¢ãŒé–¾å€¤ã‚’è¶…ãˆãŸã‚‰æ–°ã—ã„éƒ¨åˆ†åœ°å›³ã«å¤‰ãˆã‚‹
     size_t size = poses.size();
-    curSubmap.cntE = size-1;                       // •”•ª’n}‚ÌÅŒã‚ÌƒXƒLƒƒƒ“”Ô†
-    curSubmap.mps = curSubmap.subsamplePoints(nthre); // I—¹‚µ‚½•”•ª’n}‚Í‘ã•\“_‚Ì‚İ‚É‚·‚éiŒy—Ê‰»j
+    curSubmap.cntE = size-1;                       // éƒ¨åˆ†åœ°å›³ã®æœ€å¾Œã®ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
+    curSubmap.mps = curSubmap.subsamplePoints(nthre); // çµ‚äº†ã—ãŸéƒ¨åˆ†åœ°å›³ã¯ä»£è¡¨ç‚¹ã®ã¿ã«ã™ã‚‹ï¼ˆè»½é‡åŒ–ï¼‰
 
-    Submap submap(atd, size);                      // V‚µ‚¢•”•ª’n}
-    submap.addPoints(lps);                         // ƒXƒLƒƒƒ““_ŒQ‚Ì“o˜^
-    submaps.emplace_back(submap);                  // •”•ª’n}‚ğ’Ç‰Á
+    Submap submap(atd, size);                      // æ–°ã—ã„éƒ¨åˆ†åœ°å›³
+    submap.addPoints(lps);                         // ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤ã®ç™»éŒ²
+    submaps.emplace_back(submap);                  // éƒ¨åˆ†åœ°å›³ã‚’è¿½åŠ 
   }
   else {
-    curSubmap.addPoints(lps);                      // Œ»İ‚Ì•”•ª’n}‚É“_ŒQ‚ğ’Ç‰Á
+    curSubmap.addPoints(lps);                      // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³ã«ç‚¹ç¾¤ã‚’è¿½åŠ 
   }
 }
 
-// ‘S‘Ì’n}‚Ì¶¬B‹ÇŠ’n}‚à‚±‚±‚Å‚¢‚Á‚µ‚å‚Éì‚Á‚½•û‚ª‘¬‚¢
+// å…¨ä½“åœ°å›³ã®ç”Ÿæˆã€‚å±€æ‰€åœ°å›³ã‚‚ã“ã“ã§ã„ã£ã—ã‚‡ã«ä½œã£ãŸæ–¹ãŒé€Ÿã„
 void PointCloudMapLP::makeGlobalMap(){
-  globalMap.clear();                               // ‰Šú‰»
+  globalMap.clear();                               // åˆæœŸåŒ–
   localMap.clear();
-  // Œ»İˆÈŠO‚Ì‚·‚Å‚ÉŠm’è‚µ‚½•”•ª’n}‚©‚ç“_‚ğW‚ß‚é
+  // ç¾åœ¨ä»¥å¤–ã®ã™ã§ã«ç¢ºå®šã—ãŸéƒ¨åˆ†åœ°å›³ã‹ã‚‰ç‚¹ã‚’é›†ã‚ã‚‹
   for (size_t i=0; i<submaps.size()-1; i++) {
-    Submap &submap = submaps[i];                   // •”•ª’n}
-    vector<LPoint2D> &mps = submap.mps;            // •”•ª’n}‚Ì“_ŒQB‘ã•\“_‚¾‚¯‚É‚È‚Á‚Ä‚¢‚é
+    Submap &submap = submaps[i];                   // éƒ¨åˆ†åœ°å›³
+    vector<LPoint2D> &mps = submap.mps;            // éƒ¨åˆ†åœ°å›³ã®ç‚¹ç¾¤ã€‚ä»£è¡¨ç‚¹ã ã‘ã«ãªã£ã¦ã„ã‚‹
     for (size_t j=0; j<mps.size(); j++) {
-      globalMap.emplace_back(mps[j]);              // ‘S‘Ì’n}‚É‚Í‘S“_“ü‚ê‚é
+      globalMap.emplace_back(mps[j]);              // å…¨ä½“åœ°å›³ã«ã¯å…¨ç‚¹å…¥ã‚Œã‚‹
     }
-    if (i == submaps.size()-2) {                   // ‹ÇŠ’n}‚É‚ÍÅŒã‚Ì•”•ª’n}‚¾‚¯“ü‚ê‚é
+    if (i == submaps.size()-2) {                   // å±€æ‰€åœ°å›³ã«ã¯æœ€å¾Œã®éƒ¨åˆ†åœ°å›³ã ã‘å…¥ã‚Œã‚‹
       for (size_t j=0; j<mps.size(); j++) {
         localMap.emplace_back(mps[j]);
       }
     }
   }
 
-  // Œ»İ‚Ì•”•ª’n}‚Ì‘ã•\“_‚ğ‘S‘Ì’n}‚Æ‹ÇŠ’n}‚É“ü‚ê‚é
-  Submap &curSubmap = submaps.back();              // Œ»İ‚Ì•”•ª’n}
-  vector<LPoint2D> sps = curSubmap.subsamplePoints(nthre);  // ‘ã•\“_‚ğ“¾‚é
+  // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³ã®ä»£è¡¨ç‚¹ã‚’å…¨ä½“åœ°å›³ã¨å±€æ‰€åœ°å›³ã«å…¥ã‚Œã‚‹
+  Submap &curSubmap = submaps.back();              // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³
+  vector<LPoint2D> sps = curSubmap.subsamplePoints(nthre);  // ä»£è¡¨ç‚¹ã‚’å¾—ã‚‹
   for (size_t i=0; i<sps.size(); i++) {
     globalMap.emplace_back(sps[i]);
     localMap.emplace_back(sps[i]);
   }
 
-  // ˆÈ‰º‚ÍŠm”F—p
+  // ä»¥ä¸‹ã¯ç¢ºèªç”¨
   printf("curSubmap.atd=%g, atd=%g, sps.size=%lu\n", curSubmap.atdS, atd, sps.size());
   printf("submaps.size=%lu, globalMap.size=%lu\n", submaps.size(), globalMap.size());
 }
 
-// ‹ÇŠ’n}‚Ì¶¬
+// å±€æ‰€åœ°å›³ã®ç”Ÿæˆ
 void PointCloudMapLP::makeLocalMap(){
-  localMap.clear();                                // ‰Šú‰»
+  localMap.clear();                                // åˆæœŸåŒ–
   if (submaps.size() >= 2) {
-    Submap &submap = submaps[submaps.size()-2];    // ’¼‘O‚Ì•”•ª’n}‚¾‚¯g‚¤
-    vector<LPoint2D> &mps = submap.mps;            // •”•ª’n}‚Ì“_ŒQB‘ã•\“_‚¾‚¯‚É‚È‚Á‚Ä‚¢‚é
+    Submap &submap = submaps[submaps.size()-2];    // ç›´å‰ã®éƒ¨åˆ†åœ°å›³ã ã‘ä½¿ã†
+    vector<LPoint2D> &mps = submap.mps;            // éƒ¨åˆ†åœ°å›³ã®ç‚¹ç¾¤ã€‚ä»£è¡¨ç‚¹ã ã‘ã«ãªã£ã¦ã„ã‚‹
     for (size_t i=0; i<mps.size(); i++) {
       localMap.emplace_back(mps[i]);
     }
   }
 
-  // Œ»İ‚Ì•”•ª’n}‚Ì‘ã•\“_‚ğ‹ÇŠ’n}‚É“ü‚ê‚é
-  Submap &curSubmap = submaps.back();              // Œ»İ‚Ì•”•ª’n}
-  vector<LPoint2D> sps = curSubmap.subsamplePoints(nthre);  // ‘ã•\“_‚ğ“¾‚é
+  // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³ã®ä»£è¡¨ç‚¹ã‚’å±€æ‰€åœ°å›³ã«å…¥ã‚Œã‚‹
+  Submap &curSubmap = submaps.back();              // ç¾åœ¨ã®éƒ¨åˆ†åœ°å›³
+  vector<LPoint2D> sps = curSubmap.subsamplePoints(nthre);  // ä»£è¡¨ç‚¹ã‚’å¾—ã‚‹
   for (size_t i=0; i<sps.size(); i++) {
     localMap.emplace_back(sps[i]);
   }
 
-  printf("localMap.size=%lu\n", localMap.size());   // Šm”F—p
+  printf("localMap.size=%lu\n", localMap.size());   // ç¢ºèªç”¨
 }
 
 //////////
 
-// ƒ|[ƒY’²®Œã‚Ìƒƒ{ƒbƒg‹OÕnewPose‚ğ—p‚¢‚ÄA’n}‚ğÄ\’z‚·‚é
+// ãƒãƒ¼ã‚ºèª¿æ•´å¾Œã®ãƒ­ãƒœãƒƒãƒˆè»Œè·¡newPoseã‚’ç”¨ã„ã¦ã€åœ°å›³ã‚’å†æ§‹ç¯‰ã™ã‚‹
 void PointCloudMapLP::remakeMaps(const vector<Pose2D> &newPoses){
-  // Še•”•ª’n}“à‚Ì“_‚ÌˆÊ’u‚ğC³‚·‚é
+  // å„éƒ¨åˆ†åœ°å›³å†…ã®ç‚¹ã®ä½ç½®ã‚’ä¿®æ­£ã™ã‚‹
   for (size_t i=0; i<submaps.size(); i++) {
     Submap &submap = submaps[i];
-    vector<LPoint2D> &mps = submap.mps;                // •”•ª’n}‚Ì“_ŒQBŒ»İ’n}ˆÈŠO‚Í‘ã•\“_‚É‚È‚Á‚Ä‚¢‚é
+    vector<LPoint2D> &mps = submap.mps;                // éƒ¨åˆ†åœ°å›³ã®ç‚¹ç¾¤ã€‚ç¾åœ¨åœ°å›³ä»¥å¤–ã¯ä»£è¡¨ç‚¹ã«ãªã£ã¦ã„ã‚‹
     for (size_t j=0; j<mps.size(); j++) {
       LPoint2D &mp = mps[j];
-      size_t idx = mp.sid;                             // “_‚ÌƒXƒLƒƒƒ“”Ô†
-      if (idx >= poses.size()) {                       // •s³‚ÈƒXƒLƒƒƒ“”Ô†i‚ ‚Á‚½‚çƒoƒOj
+      size_t idx = mp.sid;                             // ç‚¹ã®ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
+      if (idx >= poses.size()) {                       // ä¸æ­£ãªã‚¹ã‚­ãƒ£ãƒ³ç•ªå·ï¼ˆã‚ã£ãŸã‚‰ãƒã‚°ï¼‰
         continue;
       }
 
-      const Pose2D &oldPose = poses[idx];              // mp‚É‘Î‰‚·‚éŒÃ‚¢ƒƒ{ƒbƒgˆÊ’u
-      const Pose2D &newPose = newPoses[idx];           // mp‚É‘Î‰‚·‚éV‚µ‚¢ƒƒ{ƒbƒgˆÊ’u
+      const Pose2D &oldPose = poses[idx];              // mpã«å¯¾å¿œã™ã‚‹å¤ã„ãƒ­ãƒœãƒƒãƒˆä½ç½®
+      const Pose2D &newPose = newPoses[idx];           // mpã«å¯¾å¿œã™ã‚‹æ–°ã—ã„ãƒ­ãƒœãƒƒãƒˆä½ç½®
       const double (*R1)[2] = oldPose.Rmat;
       const double (*R2)[2] = newPose.Rmat;
-      LPoint2D lp1 = oldPose.relativePoint(mp);        // oldPose‚Åmp‚ğƒZƒ“ƒTÀ•WŒn‚É•ÏŠ·
-      LPoint2D lp2 = newPose.globalPoint(lp1);         // newPose‚Åƒ|[ƒY’²®Œã‚Ì’n}À•WŒn‚É•ÏŠ·
+      LPoint2D lp1 = oldPose.relativePoint(mp);        // oldPoseã§mpã‚’ã‚»ãƒ³ã‚µåº§æ¨™ç³»ã«å¤‰æ›
+      LPoint2D lp2 = newPose.globalPoint(lp1);         // newPoseã§ãƒãƒ¼ã‚ºèª¿æ•´å¾Œã®åœ°å›³åº§æ¨™ç³»ã«å¤‰æ›
       mp.x = lp2.x;
       mp.y = lp2.y;
-      double nx = R1[0][0]*mp.nx + R1[1][0]*mp.ny;     // –@üƒxƒNƒgƒ‹‚àoldPose‚ÅƒZƒ“ƒTÀ•WŒn‚É•ÏŠ·
+      double nx = R1[0][0]*mp.nx + R1[1][0]*mp.ny;     // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã‚‚oldPoseã§ã‚»ãƒ³ã‚µåº§æ¨™ç³»ã«å¤‰æ›
       double ny = R1[0][1]*mp.nx + R1[1][1]*mp.ny;
-      double nx2 = R2[0][0]*nx + R2[0][1]*ny;          // –@üƒxƒNƒgƒ‹‚ànewPose‚Åƒ|[ƒY’²®Œã‚Ì’n}À•WŒn‚É•ÏŠ·
+      double nx2 = R2[0][0]*nx + R2[0][1]*ny;          // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«ã‚‚newPoseã§ãƒãƒ¼ã‚ºèª¿æ•´å¾Œã®åœ°å›³åº§æ¨™ç³»ã«å¤‰æ›
       double ny2 = R2[1][0]*nx + R2[1][1]*ny;
       mp.setNormal(nx2, ny2);
     }
   }
 
-  makeGlobalMap();                                     // •”•ª’n}‚©‚ç‘S‘Ì’n}‚Æ‹ÇŠ’n}‚ğ¶¬
+  makeGlobalMap();                                     // éƒ¨åˆ†åœ°å›³ã‹ã‚‰å…¨ä½“åœ°å›³ã¨å±€æ‰€åœ°å›³ã‚’ç”Ÿæˆ
 
-  for (size_t i=0; i<poses.size(); i++) {              // poses‚ğƒ|[ƒY’²®Œã‚Ì’l‚ÉXV
+  for (size_t i=0; i<poses.size(); i++) {              // posesã‚’ãƒãƒ¼ã‚ºèª¿æ•´å¾Œã®å€¤ã«æ›´æ–°
     poses[i] = newPoses[i];
   }
   lastPose = newPoses.back();

--- a/hook/PointCloudMapLP.h
+++ b/hook/PointCloudMapLP.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -20,14 +20,14 @@
 
 ///////////
 
-// •”•ª’n}
+// éƒ¨åˆ†åœ°å›³
 struct Submap
 {
-  double atdS;                              // •”•ª’n}‚Ìn“_‚Å‚Ì—İÏ‘–s‹——£
-  size_t cntS;                              // •”•ª’n}‚ÌÅ‰‚ÌƒXƒLƒƒƒ“”Ô†
-  size_t cntE;                              // •”•ª’n}‚ÌÅŒã‚ÌƒXƒLƒƒƒ“”Ô†
+  double atdS;                              // éƒ¨åˆ†åœ°å›³ã®å§‹ç‚¹ã§ã®ç´¯ç©èµ°è¡Œè·é›¢
+  size_t cntS;                              // éƒ¨åˆ†åœ°å›³ã®æœ€åˆã®ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
+  size_t cntE;                              // éƒ¨åˆ†åœ°å›³ã®æœ€å¾Œã®ã‚¹ã‚­ãƒ£ãƒ³ç•ªå·
 
-  std::vector<LPoint2D> mps;                // •”•ª’n}“à‚ÌƒXƒLƒƒƒ““_ŒQ
+  std::vector<LPoint2D> mps;                // éƒ¨åˆ†åœ°å›³å†…ã®ã‚¹ã‚­ãƒ£ãƒ³ç‚¹ç¾¤
 
   Submap() : atdS(0), cntS(0), cntE(-1) {
   }
@@ -47,18 +47,18 @@ struct Submap
 
 ///////////
 
-// •”•ª’n}‚©‚ç\¬‚³‚ê‚é“_ŒQ’n}
+// éƒ¨åˆ†åœ°å›³ã‹ã‚‰æ§‹æˆã•ã‚Œã‚‹ç‚¹ç¾¤åœ°å›³
 class PointCloudMapLP : public PointCloudMap
 {
 public:
-  static double atdThre;                    // •”•ª’n}‚Ì‹æØ‚è‚Æ‚È‚é—İÏ‘–s‹——£(atd)[m]
-  double atd;                               // Œ»İ‚Ì—İÏ‘–s‹——£(accumulated travel distance)
-  std::vector<Submap> submaps;              // •”•ª’n}
+  static double atdThre;                    // éƒ¨åˆ†åœ°å›³ã®åŒºåˆ‡ã‚Šã¨ãªã‚‹ç´¯ç©èµ°è¡Œè·é›¢(atd)[m]
+  double atd;                               // ç¾åœ¨ã®ç´¯ç©èµ°è¡Œè·é›¢(accumulated travel distance)
+  std::vector<Submap> submaps;              // éƒ¨åˆ†åœ°å›³
 
 public:
   PointCloudMapLP() {
     Submap submap;
-    submaps.emplace_back(submap);           // Å‰‚Ì•”•ª’n}‚ğì‚Á‚Ä‚¨‚­
+    submaps.emplace_back(submap);           // æœ€åˆã®éƒ¨åˆ†åœ°å›³ã‚’ä½œã£ã¦ãŠã
   }
 
   ~PointCloudMapLP() {

--- a/hook/PoseOptimizerSD.cpp
+++ b/hook/PoseOptimizerSD.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,51 +18,51 @@ using namespace std;
 
 ////////
 
-// ƒf[ƒ^‘Î‰‚Ã‚¯ŒÅ’è‚Ì‚à‚ÆA‰Šú’linitPose‚ğ—^‚¦‚Äƒƒ{ƒbƒgˆÊ’u‚Ì„’è’lestPose‚ğ‹‚ß‚é
+// ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘å›ºå®šã®ã‚‚ã¨ã€åˆæœŸå€¤initPoseã‚’ä¸ãˆã¦ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®æ¨å®šå€¤estPoseã‚’æ±‚ã‚ã‚‹
 double PoseOptimizerSD::optimizePose(Pose2D &initPose, Pose2D &estPose) {
   double th = initPose.th;
   double tx = initPose.tx;
   double ty = initPose.ty;
-  double txmin=tx, tymin=ty, thmin=th;         // ƒRƒXƒgÅ¬‚Ì‰ğ
-  double evmin = HUGE_VAL;                     // ƒRƒXƒg‚ÌÅ¬’l
-  double evold = evmin;                        // 1‚Â‘O‚ÌƒRƒXƒg’lBû‘©”»’è‚Ég‚¤
+  double txmin=tx, tymin=ty, thmin=th;         // ã‚³ã‚¹ãƒˆæœ€å°ã®è§£
+  double evmin = HUGE_VAL;                     // ã‚³ã‚¹ãƒˆã®æœ€å°å€¤
+  double evold = evmin;                        // 1ã¤å‰ã®ã‚³ã‚¹ãƒˆå€¤ã€‚åæŸåˆ¤å®šã«ä½¿ã†
 
-  double ev = cfunc->calValue(tx, ty, th);     // ƒRƒXƒgŒvZ
-  int nn=0;                                    // ŒJ‚è•Ô‚µ‰ñ”BŠm”F—p
-  double kk=0.00001;                           // Å‹}~‰º–@‚ÌƒXƒeƒbƒv•ŒW”
-  while (abs(evold-ev) > evthre) {             // û‘©”»’èB1‚Â‘O‚Ì’l‚Æ‚Ì•Ï‰»‚ª¬‚³‚¢‚ÆI—¹
+  double ev = cfunc->calValue(tx, ty, th);     // ã‚³ã‚¹ãƒˆè¨ˆç®—
+  int nn=0;                                    // ç¹°ã‚Šè¿”ã—å›æ•°ã€‚ç¢ºèªç”¨
+  double kk=0.00001;                           // æœ€æ€¥é™ä¸‹æ³•ã®ã‚¹ãƒ†ãƒƒãƒ—å¹…ä¿‚æ•°
+  while (abs(evold-ev) > evthre) {             // åæŸåˆ¤å®šã€‚1ã¤å‰ã®å€¤ã¨ã®å¤‰åŒ–ãŒå°ã•ã„ã¨çµ‚äº†
     nn++;
     evold = ev;
 
-    // ”’lŒvZ‚É‚æ‚é•Î”÷•ª
+    // æ•°å€¤è¨ˆç®—ã«ã‚ˆã‚‹åå¾®åˆ†
     double dEtx = (cfunc->calValue(tx+dd, ty, th) - ev)/dd;
     double dEty = (cfunc->calValue(tx, ty+dd, th) - ev)/dd;
     double dEth = (cfunc->calValue(tx, ty, th+da) - ev)/da;
 
-    // ”÷•ªŒW”‚Ékk‚ğ‚©‚¯‚ÄƒXƒeƒbƒv•‚É‚·‚é
+    // å¾®åˆ†ä¿‚æ•°ã«kkã‚’ã‹ã‘ã¦ã‚¹ãƒ†ãƒƒãƒ—å¹…ã«ã™ã‚‹
     double dx = -kk*dEtx;
     double dy = -kk*dEty;
     double dth = -kk*dEth;
-    tx += dx;  ty += dy;  th += dth;            // ƒXƒeƒbƒv•‚ğ‰Á‚¦‚ÄŸ‚Ì’TõˆÊ’u‚ğŒˆ‚ß‚é
+    tx += dx;  ty += dy;  th += dth;            // ã‚¹ãƒ†ãƒƒãƒ—å¹…ã‚’åŠ ãˆã¦æ¬¡ã®æ¢ç´¢ä½ç½®ã‚’æ±ºã‚ã‚‹
 
-    ev = cfunc->calValue(tx, ty, th);           // ‚»‚ÌˆÊ’u‚ÅƒRƒXƒgŒvZ
+    ev = cfunc->calValue(tx, ty, th);           // ãã®ä½ç½®ã§ã‚³ã‚¹ãƒˆè¨ˆç®—
 
-    if (ev < evmin) {                           // ev‚ª‚±‚ê‚Ü‚Å‚ÌÅ¬‚È‚çXV
+    if (ev < evmin) {                           // evãŒã“ã‚Œã¾ã§ã®æœ€å°ãªã‚‰æ›´æ–°
       evmin = ev;
       txmin = tx;  tymin = ty;  thmin = th;
     }
 
-//    printf("nn=%d, ev=%g, evold=%g, abs(evold-ev)=%g\n", nn, ev, evold, abs(evold-ev));         // Šm”F—p
+//    printf("nn=%d, ev=%g, evold=%g, abs(evold-ev)=%g\n", nn, ev, evold, abs(evold-ev));         // ç¢ºèªç”¨
   }
 
   ++allN;
   if (allN > 0 && evmin < 100) 
     sum += evmin;
-//  printf("allN=%d, evmin=%g, avg=%g\n", allN, evmin, (sum/allN));         // Šm”F—p
+//  printf("allN=%d, evmin=%g, avg=%g\n", allN, evmin, (sum/allN));         // ç¢ºèªç”¨
 
-//  printf("nn=%d, ev=%g\n", nn, ev);         // Šm”F—p
+//  printf("nn=%d, ev=%g\n", nn, ev);         // ç¢ºèªç”¨
 
-  estPose.setVal(txmin, tymin, thmin);          // Å¬’l‚ğ—^‚¦‚é‰ğ‚ğ•Û‘¶
+  estPose.setVal(txmin, tymin, thmin);          // æœ€å°å€¤ã‚’ä¸ãˆã‚‹è§£ã‚’ä¿å­˜
 
   return(evmin);
 }

--- a/hook/PoseOptimizerSD.h
+++ b/hook/PoseOptimizerSD.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,7 +17,7 @@
 
 #include "PoseOptimizer.h"
 
-// Å‹}~‰º–@‚ÅƒRƒXƒgŠÖ”‚ğÅ¬‰»‚·‚é
+// æœ€æ€¥é™ä¸‹æ³•ã§ã‚³ã‚¹ãƒˆé–¢æ•°ã‚’æœ€å°åŒ–ã™ã‚‹
 class PoseOptimizerSD : public PoseOptimizer
 {
 public:

--- a/hook/PoseOptimizerSL.cpp
+++ b/hook/PoseOptimizerSL.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -19,83 +19,83 @@ using namespace std;
 
 ////////
 
-// ƒf[ƒ^‘Î‰‚Ã‚¯ŒÅ’è‚Ì‚à‚ÆA‰Šú’linitPose‚ğ—^‚¦‚Äƒƒ{ƒbƒgˆÊ’u‚Ì„’è’lestPose‚ğ‹‚ß‚é
+// ãƒ‡ãƒ¼ã‚¿å¯¾å¿œã¥ã‘å›ºå®šã®ã‚‚ã¨ã€åˆæœŸå€¤initPoseã‚’ä¸ãˆã¦ãƒ­ãƒœãƒƒãƒˆä½ç½®ã®æ¨å®šå€¤estPoseã‚’æ±‚ã‚ã‚‹
 double PoseOptimizerSL::optimizePose(Pose2D &initPose, Pose2D &estPose) {
   double th = initPose.th;
   double tx = initPose.tx;
   double ty = initPose.ty;
-  double txmin=tx, tymin=ty, thmin=th;           // ƒRƒXƒgÅ¬‚Ì‰ğ
-  double evmin = HUGE_VAL;                       // ƒRƒXƒg‚ÌÅ¬’l
-  double evold = evmin;                          // 1‚Â‘O‚ÌƒRƒXƒg’lBû‘©”»’è‚Ég‚¤
+  double txmin=tx, tymin=ty, thmin=th;           // ã‚³ã‚¹ãƒˆæœ€å°ã®è§£
+  double evmin = HUGE_VAL;                       // ã‚³ã‚¹ãƒˆã®æœ€å°å€¤
+  double evold = evmin;                          // 1ã¤å‰ã®ã‚³ã‚¹ãƒˆå€¤ã€‚åæŸåˆ¤å®šã«ä½¿ã†
   Pose2D pose, dir;
 
-  double ev = cfunc->calValue(tx, ty, th);       // ƒRƒXƒgŒvZ
-  int nn=0;                                      // ŒJ‚è•Ô‚µ‰ñ”BŠm”F—p
-  while (abs(evold-ev) > evthre) {               // û‘©”»’èB’l‚Ì•Ï‰»‚ª¬‚³‚¢‚ÆI—¹
+  double ev = cfunc->calValue(tx, ty, th);       // ã‚³ã‚¹ãƒˆè¨ˆç®—
+  int nn=0;                                      // ç¹°ã‚Šè¿”ã—å›æ•°ã€‚ç¢ºèªç”¨
+  while (abs(evold-ev) > evthre) {               // åæŸåˆ¤å®šã€‚å€¤ã®å¤‰åŒ–ãŒå°ã•ã„ã¨çµ‚äº†
     nn++;
     evold = ev;
 
-    // ”’lŒvZ‚É‚æ‚é•Î”÷•ª
+    // æ•°å€¤è¨ˆç®—ã«ã‚ˆã‚‹åå¾®åˆ†
     double dx = (cfunc->calValue(tx+dd, ty, th) - ev)/dd;
     double dy = (cfunc->calValue(tx, ty+dd, th) - ev)/dd;
     double dth = (cfunc->calValue(tx, ty, th+da) - ev)/da;
-    tx += dx;  ty += dy;  th += dth;              // ‚¢‚Á‚½‚ñŸ‚Ì’TõˆÊ’u‚ğŒˆ‚ß‚é
+    tx += dx;  ty += dy;  th += dth;              // ã„ã£ãŸã‚“æ¬¡ã®æ¢ç´¢ä½ç½®ã‚’æ±ºã‚ã‚‹
 
-    // ƒuƒŒƒ“ƒg–@‚É‚æ‚é’¼ü’Tõ
-    pose.tx = tx;  pose.ty = ty;  pose.th = th;   // ’TõŠJn“_
-    dir.tx = dx;   dir.ty = dy;   dir.th = dth;   // ’Tõ•ûŒü
-    search(ev, pose, dir);                        // ’¼ü’TõÀs
-    tx = pose.tx;  ty = pose.ty;  th = pose.th;   // ’¼ü’Tõ‚Å‹‚ß‚½ˆÊ’u
+    // ãƒ–ãƒ¬ãƒ³ãƒˆæ³•ã«ã‚ˆã‚‹ç›´ç·šæ¢ç´¢
+    pose.tx = tx;  pose.ty = ty;  pose.th = th;   // æ¢ç´¢é–‹å§‹ç‚¹
+    dir.tx = dx;   dir.ty = dy;   dir.th = dth;   // æ¢ç´¢æ–¹å‘
+    search(ev, pose, dir);                        // ç›´ç·šæ¢ç´¢å®Ÿè¡Œ
+    tx = pose.tx;  ty = pose.ty;  th = pose.th;   // ç›´ç·šæ¢ç´¢ã§æ±‚ã‚ãŸä½ç½®
 
-    ev = cfunc->calValue(tx, ty, th);             // ‹‚ß‚½ˆÊ’u‚ÅƒRƒXƒgŒvZ
+    ev = cfunc->calValue(tx, ty, th);             // æ±‚ã‚ãŸä½ç½®ã§ã‚³ã‚¹ãƒˆè¨ˆç®—
 
-    if (ev < evmin) {                             // ƒRƒXƒg‚ª‚±‚ê‚Ü‚Å‚ÌÅ¬‚È‚çXV
+    if (ev < evmin) {                             // ã‚³ã‚¹ãƒˆãŒã“ã‚Œã¾ã§ã®æœ€å°ãªã‚‰æ›´æ–°
       evmin = ev;
       txmin = tx;  tymin = ty;  thmin = th;
     }
 
-//    printf("nn=%d, ev=%g, evold=%g, abs(evold-ev)=%g\n", nn, ev, evold, abs(evold-ev));         // Šm”F—p
+//    printf("nn=%d, ev=%g, evold=%g, abs(evold-ev)=%g\n", nn, ev, evold, abs(evold-ev));         // ç¢ºèªç”¨
   }
   ++allN;
   if (allN > 0 && evmin < 100) 
     sum += evmin;
-//  printf("allN=%d, nn=%d, evmin=%g, avg=%g, evthre=%g\n", allN, nn, evmin, (sum/allN), evthre);         // Šm”F—p
+//  printf("allN=%d, nn=%d, evmin=%g, avg=%g, evthre=%g\n", allN, nn, evmin, (sum/allN), evthre);         // ç¢ºèªç”¨
 
-//  printf("nn=%d, evmin=%g\n", nn, evmin);       // Šm”F—p
+//  printf("nn=%d, evmin=%g\n", nn, evmin);       // ç¢ºèªç”¨
 
-  estPose.setVal(txmin, tymin, thmin);            // Å¬’l‚ğ—^‚¦‚é‰ğ‚ğ•Û‘¶
+  estPose.setVal(txmin, tymin, thmin);            // æœ€å°å€¤ã‚’ä¸ãˆã‚‹è§£ã‚’ä¿å­˜
 
   return(evmin);
 }
 
 ////////// Line search ///////////
 
-// boostƒ‰ƒCƒuƒ‰ƒŠ‚ÌƒuƒŒƒ“ƒg–@‚Å’¼ü’Tõ‚ğs‚¤B
-// pose‚ğn“_‚ÉAdp•ûŒü‚É‚Ç‚ê‚¾‚¯i‚ß‚Î‚æ‚¢‚©ƒXƒeƒbƒv•‚ğŒ©‚Â‚¯‚éB
+// boostãƒ©ã‚¤ãƒ–ãƒ©ãƒªã®ãƒ–ãƒ¬ãƒ³ãƒˆæ³•ã§ç›´ç·šæ¢ç´¢ã‚’è¡Œã†ã€‚
+// poseã‚’å§‹ç‚¹ã«ã€dpæ–¹å‘ã«ã©ã‚Œã ã‘é€²ã‚ã°ã‚ˆã„ã‹ã‚¹ãƒ†ãƒƒãƒ—å¹…ã‚’è¦‹ã¤ã‘ã‚‹ã€‚
 double PoseOptimizerSL::search(double ev0, Pose2D &pose, Pose2D &dp) {
-  int bits = numeric_limits<double>::digits;         // ’Tõ¸“x
-  boost::uintmax_t maxIter=40;                       // Å‘åŒJ‚è•Ô‚µ‰ñ”BŒoŒ±“I‚ÉŒˆ‚ß‚é
+  int bits = numeric_limits<double>::digits;         // æ¢ç´¢ç²¾åº¦
+  boost::uintmax_t maxIter=40;                       // æœ€å¤§ç¹°ã‚Šè¿”ã—å›æ•°ã€‚çµŒé¨“çš„ã«æ±ºã‚ã‚‹
   pair<double, double> result = 
     boost::math::tools::brent_find_minima(
     [this, &pose, &dp](double tt) {return (objFunc(tt, pose, dp));},
-    -2.0, 2.0, bits, maxIter);                       // ’Tõ”ÍˆÍ(-2.0,2.0)
+    -2.0, 2.0, bits, maxIter);                       // æ¢ç´¢ç¯„å›²(-2.0,2.0)
 
-  double t = result.first;                           // ‹‚ß‚éƒXƒeƒbƒv•
-  double v = result.second;                          // ‹‚ß‚éÅ¬’l
+  double t = result.first;                           // æ±‚ã‚ã‚‹ã‚¹ãƒ†ãƒƒãƒ—å¹…
+  double v = result.second;                          // æ±‚ã‚ã‚‹æœ€å°å€¤
 
-  pose.tx = pose.tx + t*dp.tx;                       // ‹‚ß‚éÅ¬‰ğ‚ğpose‚ÉŠi”[
+  pose.tx = pose.tx + t*dp.tx;                       // æ±‚ã‚ã‚‹æœ€å°è§£ã‚’poseã«æ ¼ç´
   pose.ty = pose.ty + t*dp.ty;
   pose.th = MyUtil::add(pose.th, t*dp.th);
 
   return(v);
 }  
 
-// ’¼ü’Tõ‚Ì–Ú“IŠÖ”Btt‚ªƒXƒeƒbƒv•
+// ç›´ç·šæ¢ç´¢ã®ç›®çš„é–¢æ•°ã€‚ttãŒã‚¹ãƒ†ãƒƒãƒ—å¹…
 double PoseOptimizerSL::objFunc(double tt, Pose2D &pose, Pose2D &dp) {
-  double tx = pose.tx + tt*dp.tx;                     // pose‚©‚çdp•ûŒü‚Étt‚¾‚¯i‚Ş
+  double tx = pose.tx + tt*dp.tx;                     // poseã‹ã‚‰dpæ–¹å‘ã«ttã ã‘é€²ã‚€
   double ty = pose.ty + tt*dp.ty;
   double th = MyUtil::add(pose.th, tt*dp.th);
-  double v = cfunc->calValue(tx, ty, th);             // ƒRƒXƒgŠÖ”’l
+  double v = cfunc->calValue(tx, ty, th);             // ã‚³ã‚¹ãƒˆé–¢æ•°å€¤
 
   return(v);
 }

--- a/hook/PoseOptimizerSL.h
+++ b/hook/PoseOptimizerSL.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,7 +17,7 @@
 
 #include "PoseOptimizer.h"
 
-// ’¼ü’Tõ‚Â‚«‚ÌÅ‹}~‰º–@‚ÅƒRƒXƒgŠÖ”‚ğÅ¬‰»‚·‚é
+// ç›´ç·šæ¢ç´¢ã¤ãã®æœ€æ€¥é™ä¸‹æ³•ã§ã‚³ã‚¹ãƒˆé–¢æ•°ã‚’æœ€å°åŒ–ã™ã‚‹
 class PoseOptimizerSL : public PoseOptimizer
 {
 public:

--- a/hook/RefScanMakerBS.cpp
+++ b/hook/RefScanMakerBS.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -17,24 +17,24 @@
 using namespace std;
 
 const Scan2D *RefScanMakerBS::makeRefScan() {
-  vector<LPoint2D> &refLps = refScan.lps;         // QÆƒXƒLƒƒƒ“‚Ì“_ŒQ‚ÌƒRƒ“ƒeƒi
+  vector<LPoint2D> &refLps = refScan.lps;         // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤ã®ã‚³ãƒ³ãƒ†ãƒŠ
   refLps.clear();
 
-  Pose2D lastPose = pcmap->getLastPose();         // “_ŒQ’n}‚É•Û‘¶‚µ‚½ÅŒã‚Ì„’èˆÊ’u
+  Pose2D lastPose = pcmap->getLastPose();         // ç‚¹ç¾¤åœ°å›³ã«ä¿å­˜ã—ãŸæœ€å¾Œã®æ¨å®šä½ç½®
   double (*R)[2] = lastPose.Rmat;
   double tx = lastPose.tx;
   double ty = lastPose.ty;
 
-  // “_ŒQ’n}‚É•Û‘¶‚µ‚½ÅŒã‚ÌƒXƒLƒƒƒ“‚ğQÆƒXƒLƒƒƒ“‚É‚·‚é
+  // ç‚¹ç¾¤åœ°å›³ã«ä¿å­˜ã—ãŸæœ€å¾Œã®ã‚¹ã‚­ãƒ£ãƒ³ã‚’å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã«ã™ã‚‹
   const vector<LPoint2D> &lps = pcmap->lastScan.lps;
   for (size_t i=0; i<lps.size(); i++) {
-    const LPoint2D &mp = lps[i];                  // QÆƒXƒLƒƒƒ“‚Ì“_
+    const LPoint2D &mp = lps[i];                  // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹
 
-    // ƒXƒLƒƒƒ“‚Íƒƒ{ƒbƒgÀ•WŒn‚È‚Ì‚ÅA’n}À•WŒn‚É•ÏŠ·
+    // ã‚¹ã‚­ãƒ£ãƒ³ã¯ãƒ­ãƒœãƒƒãƒˆåº§æ¨™ç³»ãªã®ã§ã€åœ°å›³åº§æ¨™ç³»ã«å¤‰æ›
     LPoint2D rp;
-    rp.x = R[0][0]*mp.x + R[0][1]*mp.y + tx;      // “_‚ÌˆÊ’u
+    rp.x = R[0][0]*mp.x + R[0][1]*mp.y + tx;      // ç‚¹ã®ä½ç½®
     rp.y = R[1][0]*mp.x + R[1][1]*mp.y + ty;
-    rp.nx = R[0][0]*mp.nx + R[0][1]*mp.ny;        // –@üƒxƒNƒgƒ‹
+    rp.nx = R[0][0]*mp.nx + R[0][1]*mp.ny;        // æ³•ç·šãƒ™ã‚¯ãƒˆãƒ«
     rp.ny = R[1][0]*mp.nx + R[1][1]*mp.ny;
     refLps.emplace_back(rp);
   }

--- a/hook/RefScanMakerBS.h
+++ b/hook/RefScanMakerBS.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),

--- a/hook/RefScanMakerLM.cpp
+++ b/hook/RefScanMakerLM.cpp
@@ -1,4 +1,4 @@
-/****************************************************************************
+ï»¿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),
@@ -18,13 +18,13 @@ using namespace std;
 
 
 const Scan2D *RefScanMakerLM::makeRefScan() {
-  vector<LPoint2D> &refLps = refScan.lps;         // QÆƒXƒLƒƒƒ“‚Ì“_ŒQ‚ÌƒRƒ“ƒeƒi
+  vector<LPoint2D> &refLps = refScan.lps;         // å‚ç…§ã‚¹ã‚­ãƒ£ãƒ³ã®ç‚¹ç¾¤ã®ã‚³ãƒ³ãƒ†ãƒŠ
   refLps.clear();
 
-  const vector<LPoint2D> &localMap = pcmap->localMap;  // “_ŒQ’n}‚Ì‹ÇŠ’n}
+  const vector<LPoint2D> &localMap = pcmap->localMap;  // ç‚¹ç¾¤åœ°å›³ã®å±€æ‰€åœ°å›³
   for (size_t i=0; i<localMap.size(); i++) {
     const LPoint2D &rp = localMap[i];
-    refLps.emplace_back(rp);                           // ’P‚ÉƒRƒs[
+    refLps.emplace_back(rp);                           // å˜ã«ã‚³ãƒ”ãƒ¼
   }
 
   return(&refScan);

--- a/hook/RefScanMakerLM.h
+++ b/hook/RefScanMakerLM.h
@@ -1,4 +1,4 @@
-/****************************************************************************
+﻿/****************************************************************************
  * LittleSLAM: 2D-Laser SLAM for educational use
  * Copyright (C) 2017-2018 Masahiro Tomono
  * Copyright (C) 2018 Future Robotics Technology Center (fuRo),


### PR DESCRIPTION
`*.cpp, *.h, *.md, CMakeList.txt` のファイルエンコーディングを一律、UTF-8 (BOM付き) に変換する変更です。変更の意図については  https://github.com/furo-org/LittleSLAM/issues/1 に書きました。

以下のshell scriptでファイル一括変換しました。
```
files=`find . -type f -name "*.cpp" -o -name "*.h" -o -name "*.md" -o -name "CMakeLists.txt"`
for file in $files;
do
match=`file $file | grep Non-ISO`;
if [ ${#match} == 0 ]; then
    nkf --oc=UTF-8-BOM --overwrite $file
else 
    nkf --ic=CP932 --oc=UTF-8-BOM --overwrite $file
fi
done;
```

また、CMakeListのUNIX系OS向けにcharsetを指定する記述を削除しました