### PR TITLE
p2oをsubmoduleとして追加

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "p2o"]
+	path = p2o
+	url = https://github.com/furo-org/p2o.git

--- a/doc/install-linux.md
+++ b/doc/install-linux.md
@@ -27,6 +27,10 @@ LittleSLAM-master.zipをダウンロードします。
 LittleSLAM-master.zipの中の"LittleSLAM-master"ディレクトリの下の
 4個のディレクトリと3個のファイルを"\~/LittleSLAM"の下にコピーします。  
 (B) gitを使って、リポジトリをcloneします。
+```
+git clone --recursive https://github.com/furo-org/LittleSLAM.git
+```
+この方法を使った場合は次の「p2oの展開」の操作は不要です。
 
 - p2oの展開  
 "\~/LittleSLAM"の下にp2oディレクトリを作成します。  

--- a/doc/install-linux.md
+++ b/doc/install-linux.md
@@ -33,7 +33,6 @@ git clone --recursive https://github.com/furo-org/LittleSLAM.git
 この方法を使った場合は次の「p2oの展開」の操作は不要です。
 
 - p2oの展開  
-"\~/LittleSLAM"の下にp2oディレクトリを作成します。  
 前述のp2o-master.zipの中のファイル"p2o.h"を"\~/LittleSLAM/p2o"にコピーします。  
 
 - buildディレクトリの作成  

--- a/doc/install-win.md
+++ b/doc/install-win.md
@@ -40,6 +40,10 @@ LittleSLAM-master.zipをダウンロードします。
 LittleSLAM-master.zipの中の"LittleSLAM-master"フォルダの下の
 4個のフォルダと3個のファイルを"C:\abc\LittleSLAM"の下にコピーします。  
 (B) gitを使って、リポジトリをcloneします。  
+```
+git clone --recursive https://github.com/furo-org/LittleSLAM.git
+```
+この方法を使った場合は次の「p2oの展開」の操作は不要です。
 
 - p2oの展開   
 "C:\abc\LittleSLAM"の下に"p2o"フォルダを作成します。  

--- a/doc/install-win.md
+++ b/doc/install-win.md
@@ -46,7 +46,6 @@ git clone --recursive https://github.com/furo-org/LittleSLAM.git
 この方法を使った場合は次の「p2oの展開」の操作は不要です。
 
 - p2oの展開   
-"C:\abc\LittleSLAM"の下に"p2o"フォルダを作成します。  
 前述のp2o-master.zipの中のファイル"p2o.h"を"C:\abc\LittleSLAM\p2o"の下にコピーします。  
 
 - buildフォルダの作成  


### PR DESCRIPTION
p2oをgit submoduleで追加．

これにより，
- p2oを手動で取得・配置する必要がなくなる
- p2oのどのバージョンを使うか明示的に決められる
というメリットがあります．


